### PR TITLE
Integrate infrastructure layer (UserRepository + PasswordHasher) into register-user feature

### DIFF
--- a/.idea/workspace.xml
+++ b/.idea/workspace.xml
@@ -6,8 +6,8 @@
   <component name="ChangeListManager">
     <list default="true" id="6952a861-17ec-40ad-b866-c564752c14a8" name="変更" comment="">
       <change beforePath="$PROJECT_DIR$/.idea/workspace.xml" beforeDir="false" afterPath="$PROJECT_DIR$/.idea/workspace.xml" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/src/app/User/Domain/RepositoryInterface/UserRepositoryInterface.php" beforeDir="false" afterPath="$PROJECT_DIR$/src/app/User/Domain/RepositoryInterface/UserRepositoryInterface.php" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/src/app/User/Domain/Service/UserDuplicationChecker.php" beforeDir="false" afterPath="$PROJECT_DIR$/src/app/User/Domain/Service/UserDuplicationChecker.php" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/app/User/Domain/Entity/UserEntity.php" beforeDir="false" afterPath="$PROJECT_DIR$/src/app/User/Domain/Entity/UserEntity.php" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/app/User/Infrastructure/Repository/UserRepository.php" beforeDir="false" afterPath="$PROJECT_DIR$/src/app/User/Infrastructure/Repository/UserRepository.php" afterDir="false" />
     </list>
     <option name="SHOW_DIALOG" value="false" />
     <option name="HIGHLIGHT_CONFLICTS" value="true" />
@@ -160,7 +160,7 @@
   "keyToString": {
     "RunOnceActivity.ShowReadmeOnStart": "true",
     "RunOnceActivity.git.unshallow": "true",
-    "git-widget-placeholder": "feature/email-validation-domain",
+    "git-widget-placeholder": "feature/register-user-infra-repository-save",
     "node.js.detected.package.eslint": "true",
     "node.js.selected.package.eslint": "(autodetect)",
     "nodejs_package_manager_path": "npm",

--- a/.idea/workspace.xml
+++ b/.idea/workspace.xml
@@ -5,8 +5,10 @@
   </component>
   <component name="ChangeListManager">
     <list default="true" id="6952a861-17ec-40ad-b866-c564752c14a8" name="変更" comment="">
+      <change afterPath="$PROJECT_DIR$/src/app/User/Infrastructure/BcryptPasswordHasher.php" afterDir="false" />
       <change beforePath="$PROJECT_DIR$/.idea/workspace.xml" beforeDir="false" afterPath="$PROJECT_DIR$/.idea/workspace.xml" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/src/app/User/Domain/Entity/UserEntity.php" beforeDir="false" afterPath="$PROJECT_DIR$/src/app/User/Domain/Entity/UserEntity.php" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/app/Providers/AppServiceProvider.php" beforeDir="false" afterPath="$PROJECT_DIR$/src/app/Providers/AppServiceProvider.php" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/app/User/Domain/InfrastructureTest/UserRepositoryTest.php" beforeDir="false" afterPath="$PROJECT_DIR$/src/app/User/Infrastructure/InfrastructureTest/UserRepositoryTest.php" afterDir="false" />
       <change beforePath="$PROJECT_DIR$/src/app/User/Infrastructure/Repository/UserRepository.php" beforeDir="false" afterPath="$PROJECT_DIR$/src/app/User/Infrastructure/Repository/UserRepository.php" afterDir="false" />
     </list>
     <option name="SHOW_DIALOG" value="false" />
@@ -160,7 +162,7 @@
   "keyToString": {
     "RunOnceActivity.ShowReadmeOnStart": "true",
     "RunOnceActivity.git.unshallow": "true",
-    "git-widget-placeholder": "feature/register-user-infra-repository-save",
+    "git-widget-placeholder": "feature/register-user-infra-password-hasher",
     "node.js.detected.package.eslint": "true",
     "node.js.selected.package.eslint": "(autodetect)",
     "nodejs_package_manager_path": "npm",

--- a/src/app/Providers/AppServiceProvider.php
+++ b/src/app/Providers/AppServiceProvider.php
@@ -3,6 +3,8 @@
 namespace App\Providers;
 
 use Illuminate\Support\ServiceProvider;
+use App\User\Domain\RepositoryInterface\PasswordHasherInterface;
+use App\User\Infrastructure\BcryptPasswordHasher;
 
 class AppServiceProvider extends ServiceProvider
 {
@@ -11,7 +13,10 @@ class AppServiceProvider extends ServiceProvider
      */
     public function register(): void
     {
-        //
+        $this->app->bind(
+            PasswordHasherInterface::class,
+            BcryptPasswordHasher::class
+        );
     }
 
     /**

--- a/src/app/User/Domain/Entity/UserEntity.php
+++ b/src/app/User/Domain/Entity/UserEntity.php
@@ -2,34 +2,34 @@
 
 namespace App\User\Domain\Entity;
 
-use App\Common\Domain\Userid;
+use App\Common\Domain\UserId;
 use App\User\Domain\ValueObject\Email;
 use App\User\Domain\ValueObject\Password;
+use LogicException;
 
 class UserEntity
 {
-    private readonly ?UserId $id;
     private readonly string $firstName;
     private readonly string $lastName;
     private readonly Email $email;
-    private readonly Password $password;
+    private readonly ?Password $password;
     private readonly ?string $bio;
     private readonly ?string $location;
     private readonly array $skills;
     private readonly ?string $profileImage;
+    private readonly ?UserId $id;
 
     public function __construct(
-        ?UserId $id,
         string $firstName,
         string $lastName,
         Email $email,
-        Password $password,
+        ?Password $password = null,
         ?string $bio = null,
         ?string $location = null,
         array $skills = [],
-        ?string $profileImage = null
+        ?string $profileImage = null,
+        ?UserId $id = null
     ) {
-        $this->id = $id;
         $this->firstName = $firstName;
         $this->lastName = $lastName;
         $this->email = $email;
@@ -38,6 +38,7 @@ class UserEntity
         $this->location = $location;
         $this->skills = $skills;
         $this->profileImage = $profileImage;
+        $this->id = $id;
     }
 
     public function getUserId(): ?UserId
@@ -60,9 +61,18 @@ class UserEntity
         return $this->email;
     }
 
-    public function getPassword(): Password
+    public function getPassword(): ?Password
     {
         return $this->password;
+    }
+
+    public function getValidatedHashedPassword(): string
+    {
+        if ($this->password === null) {
+            throw new LogicException('Password is null.');
+        }
+
+        return $this->password->getHashedPassword();
     }
 
     public function getBio(): ?string

--- a/src/app/User/Domain/Factory/UserEntityFactory.php
+++ b/src/app/User/Domain/Factory/UserEntityFactory.php
@@ -13,15 +13,17 @@ class UserEntityFactory
     public static function build(array $data, PasswordHasherInterface $hasher): UserEntity
     {
         return new UserEntity(
-            id: new UserId($data['id']) ?? null,
+            id: isset($data['id']) ? new UserId($data['id']) : null,
             firstName: $data['first_name'],
             lastName: $data['last_name'],
             email: new Email($data['email']),
             password: Password::fromPlainText($data['password'], $hasher),
-            bio: $data['bio'] ?? null,
-            location: $data['location'] ?? null,
-            skills: $data['skills'] ?? [],
-            profileImage: $data['profile_image'] ?? null
+            bio: isset($data['bio']) ? $data['bio'] : null,
+            location: isset($data['location']) ? $data['location'] : null,
+            skills: is_string($data['skills'])
+                ? json_decode($data['skills'], true)
+                : (is_array($data['skills']) ? $data['skills'] : []),
+            profileImage: isset($data['profile_image']) ? $data['profile_image'] : null
         );
     }
 }

--- a/src/app/User/Domain/Factory/UserFromModelEntityFactory.php
+++ b/src/app/User/Domain/Factory/UserFromModelEntityFactory.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace App\User\Domain\Factory;
+
+use App\Models\User;
+use App\User\Domain\Entity\UserEntity;
+use App\User\Domain\ValueObject\Email;
+use App\User\Domain\ValueObject\Password;
+use App\Common\Domain\UserId;
+
+class UserFromModelEntityFactory
+{
+    public static function buildFromModel(User $model): UserEntity
+    {
+        return new UserEntity(
+            id: new UserId($model->id),
+            firstName: $model->first_name,
+            lastName: $model->last_name,
+            email: new Email($model->email),
+            password: Password::fromHashed($model->password),
+            bio: isset($model->bio) ? $model->bio : null,
+            location: isset($model->location) ? $model->location : null,
+            skills: is_string($model->skills)
+                ? json_decode($model->skills, true)
+                : (is_array($model->skills) ? $model->skills : []),
+            profileImage: isset($model->profile_image) ? $model->profile_image : null
+        );
+    }
+}

--- a/src/app/User/Domain/InfrastructureTest/UserRepositoryTest.php
+++ b/src/app/User/Domain/InfrastructureTest/UserRepositoryTest.php
@@ -1,0 +1,89 @@
+<?php
+
+namespace App\User\Domain\InfrastructureTest;
+
+use App\User\Domain\Entity\UserEntity;
+use App\User\Domain\Factory\UserEntityFactory;
+use App\User\Domain\RepositoryInterface\PasswordHasherInterface;
+use App\User\Infrastructure\Repository\UserRepository;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Mockery;
+use Tests\TestCase;
+
+class UserRepositoryTest extends TestCase
+{
+    use RefreshDatabase;
+    private UserRepository $repository;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->repository = new UserRepository();
+    }
+
+    protected function tearDown(): void
+    {
+        parent::tearDown();
+    }
+
+    /**
+     * @test
+     * @testdox register successfully (check instance type)
+     */
+    public function test1(): void
+    {
+        $result = $this->repository->save($this->mockEntity());
+
+        $this->assertInstanceOf(UserEntity::class, $result);
+    }
+
+    /**
+     * @test
+     * @testdox register successfully (check if the entity is saved)
+     */
+    public function test2(): void
+    {
+        $this->repository->save($this->mockEntity());
+
+        $this->assertDatabaseHas('users', [
+            'first_name' => $this->mockRequest()['first_name'],
+            'last_name' => $this->mockRequest()['last_name'],
+            'email' => $this->mockRequest()['email'],
+            'bio' => $this->mockRequest()['bio'],
+            'location' => $this->mockRequest()['location'],
+            'skills' => json_encode($this->mockRequest()['skills'], JSON_UNESCAPED_UNICODE),
+            'profile_image' => $this->mockRequest()['profile_image'],
+        ], 'mysql');
+    }
+
+    private function mockRequest(): array
+    {
+        return [
+            'first_name' => 'Sergio',
+            'last_name' => 'Ramos',
+            'email' => 'real-madrid15@test.com',
+            'password' => 'el-capitán-1234',
+            'bio' => 'Real Madrid player',
+            'location' => 'Madrid',
+            'skills' => ['Football', 'Leadership'],
+            'profile_image' => 'https://example.com/sergio.jpg'
+        ];
+    }
+
+    private function mockHasher(): PasswordHasherInterface
+    {
+        $hasher = Mockery::mock(PasswordHasherInterface::class);
+
+        $hasher
+            ->shouldReceive('hash')
+            ->with($this->mockRequest()['password'])
+            ->andReturn($this->mockRequest()['password']);
+
+        return $hasher;
+    }
+
+    private function mockEntity(): UserEntity
+    {
+        return UserEntityFactory::build($this->mockRequest(), $this->mockHasher());
+    }
+}

--- a/src/app/User/Domain/RepositoryInterface/UserRepositoryInterface.php
+++ b/src/app/User/Domain/RepositoryInterface/UserRepositoryInterface.php
@@ -3,11 +3,12 @@
 namespace App\User\Domain\RepositoryInterface;
 
 use App\Models\User;
+use App\User\Domain\Entity\UserEntity;
 use App\User\Domain\ValueObject\Email;
 
 interface UserRepositoryInterface
 {
-    public function save(User $user): void;
+    public function save(UserEntity $entity): ?UserEntity;
 
     public function existsByEmail(Email $email): bool;
 }

--- a/src/app/User/Domain/ValueObject/Email.php
+++ b/src/app/User/Domain/ValueObject/Email.php
@@ -17,7 +17,7 @@ final class Email
         $this->value = $value;
     }
 
-    public function getEmail(): string
+    public function getValue(): string
     {
         return $this->value;
     }

--- a/src/app/User/Infrastructure/BcryptPasswordHasher.php
+++ b/src/app/User/Infrastructure/BcryptPasswordHasher.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace App\User\Infrastructure;
+
+use Illuminate\Support\Facades\Hash;
+use App\User\Domain\RepositoryInterface\PasswordHasherInterface;
+
+class BcryptPasswordHasher implements PasswordHasherInterface
+{
+    public function hash(string $plain): string
+    {
+        return Hash::make($plain);
+    }
+}

--- a/src/app/User/Infrastructure/InfrastructureTest/BcryptPasswordHasherTest.php
+++ b/src/app/User/Infrastructure/InfrastructureTest/BcryptPasswordHasherTest.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Tests\Unit\Infrastructure\Auth;
+
+use Tests\TestCase;
+use Illuminate\Support\Facades\Hash;
+use App\User\Infrastructure\BcryptPasswordHasher;
+
+class BcryptPasswordHasherTest extends TestCase
+{
+    /**
+     * @test
+     * @testdox hasher test successfully
+     */
+    public function it_hashes_plain_text_password_correctly(): void
+    {
+        $hasher = new BcryptPasswordHasher();
+        $plain = 'secure-password-123';
+
+        $hashed = $hasher->hash($plain);
+
+        $this->assertNotEquals($plain, $hashed);
+        $this->assertTrue(Hash::check($plain, $hashed));
+    }
+}

--- a/src/app/User/Infrastructure/InfrastructureTest/UserRepositoryTest.php
+++ b/src/app/User/Infrastructure/InfrastructureTest/UserRepositoryTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace App\User\Domain\InfrastructureTest;
+namespace App\User\Infrastructure\InfrastructureTest;
 
 use App\User\Domain\Entity\UserEntity;
 use App\User\Domain\Factory\UserEntityFactory;
@@ -13,17 +13,22 @@ use Tests\TestCase;
 class UserRepositoryTest extends TestCase
 {
     use RefreshDatabase;
+
     private UserRepository $repository;
+    private PasswordHasherInterface $hasher;
 
     protected function setUp(): void
     {
         parent::setUp();
-        $this->repository = new UserRepository();
+
+        $this->hasher = $this->mockHasher();
+        $this->repository = new UserRepository($this->hasher);
     }
 
     protected function tearDown(): void
     {
         parent::tearDown();
+        Mockery::close();
     }
 
     /**
@@ -73,9 +78,7 @@ class UserRepositoryTest extends TestCase
     private function mockHasher(): PasswordHasherInterface
     {
         $hasher = Mockery::mock(PasswordHasherInterface::class);
-
-        $hasher
-            ->shouldReceive('hash')
+        $hasher->shouldReceive('hash')
             ->with($this->mockRequest()['password'])
             ->andReturn($this->mockRequest()['password']);
 
@@ -84,6 +87,6 @@ class UserRepositoryTest extends TestCase
 
     private function mockEntity(): UserEntity
     {
-        return UserEntityFactory::build($this->mockRequest(), $this->mockHasher());
+        return UserEntityFactory::build($this->mockRequest(), $this->hasher); // ✅ 変更
     }
 }

--- a/src/app/User/Infrastructure/Repository/UserRepository.php
+++ b/src/app/User/Infrastructure/Repository/UserRepository.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace App\User\Infrastructure\Repository;
+
+use App\Models\User;
+use App\User\Domain\Entity\UserEntity;
+use App\User\Domain\Factory\UserFromModelEntityFactory;
+use App\User\Domain\RepositoryInterface\UserRepositoryInterface;
+use App\User\Domain\ValueObject\Email;
+use InvalidArgumentException;
+
+class UserRepository implements UserRepositoryInterface
+{
+    public function save(UserEntity $entity): ?UserEntity
+    {
+        $notValidatedEmail = $this->existsByEmail($entity->getEmail());
+
+        if ($notValidatedEmail) {
+            throw new InvalidArgumentException('Email is already in use.');
+        }
+
+        $model = User::create([
+            'first_name' => $entity->getFirstName(),
+            'last_name' => $entity->getLastName(),
+            'email' => $entity->getEmail()->getValue(),
+            'password' => $entity->getValidatedHashedPassword($entity),
+            'bio' => $entity->getBio(),
+            'location' => $entity->getLocation(),
+            'skills' => json_encode($entity->getSkills()),
+            'profile_image' => $entity->getProfileImage()
+        ]);
+
+        return UserFromModelEntityFactory::buildFromModel($model);
+    }
+
+    public function existsByEmail(Email $email): bool
+    {
+        return User::where('email', $email->getValue())->exists();
+    }
+}

--- a/src/app/User/Infrastructure/Repository/UserRepository.php
+++ b/src/app/User/Infrastructure/Repository/UserRepository.php
@@ -7,23 +7,26 @@ use App\User\Domain\Entity\UserEntity;
 use App\User\Domain\Factory\UserFromModelEntityFactory;
 use App\User\Domain\RepositoryInterface\UserRepositoryInterface;
 use App\User\Domain\ValueObject\Email;
-use InvalidArgumentException;
+use App\User\Domain\RepositoryInterface\PasswordHasherInterface;
+use LogicException;
 
 class UserRepository implements UserRepositoryInterface
 {
+    public function __construct(
+        private readonly PasswordHasherInterface $hasher
+    ) {}
+
     public function save(UserEntity $entity): ?UserEntity
     {
-        $notValidatedEmail = $this->existsByEmail($entity->getEmail());
-
-        if ($notValidatedEmail) {
-            throw new InvalidArgumentException('Email is already in use.');
-        }
+        $hashed = $entity->getPassword()
+            ? $entity->getPassword()->getHashedPassword()
+            : throw new LogicException('Password is missing.');
 
         $model = User::create([
             'first_name' => $entity->getFirstName(),
             'last_name' => $entity->getLastName(),
             'email' => $entity->getEmail()->getValue(),
-            'password' => $entity->getValidatedHashedPassword($entity),
+            'password' => $hashed,
             'bio' => $entity->getBio(),
             'location' => $entity->getLocation(),
             'skills' => json_encode($entity->getSkills()),


### PR DESCRIPTION
### Description

This pull request merges the infrastructure-layer components defined in [issue #12 (infra scope)](https://github.com/zigzagdev/portfolio-backend/issues/12?issue=zigzagdev%7Cportfolio-backend%7C24) into the `register-user` feature branch.

#### Integrated components:
- `UserRepository`
  - Implements `UserRepositoryInterface`
  - Handles `save()` and `existsByEmail()` using Eloquent
  - Returns fully constructed `UserEntity` via `UserFromModelEntityFactory`

- `BcryptPasswordHasher`
  - Implements `PasswordHasherInterface`
  - Delegates hashing to Laravel's `Hash::make()`
  - Bound in DI container (if applicable)

#### Purpose:
These infrastructure components are foundational to completing the `register-user` feature, and are now being merged for integration with the Application and UseCase layers.