### PR TITLE
Implement RegisterUserUsecase for user registration logic

### DIFF
--- a/.idea/php-test-framework.xml
+++ b/.idea/php-test-framework.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="PhpTestFrameworkVersionCache">
+    <tools_cache>
+      <tool tool_name="PHPUnit">
+        <cache>
+          <versions>
+            <info id="ローカル/src/vendor/autoload.php" version="11.5.19" />
+          </versions>
+        </cache>
+      </tool>
+    </tools_cache>
+  </component>
+</project>

--- a/.idea/workspace.xml
+++ b/.idea/workspace.xml
@@ -5,13 +5,7 @@
   </component>
   <component name="ChangeListManager">
     <list default="true" id="6952a861-17ec-40ad-b866-c564752c14a8" name="変更" comment="">
-      <change afterPath="$PROJECT_DIR$/src/app/User/Application/ApplicationTest/RegisterUserDtoFactoryTest.php" afterDir="false" />
-      <change afterPath="$PROJECT_DIR$/src/app/User/Application/Dto/RegisterUserDto.php" afterDir="false" />
-      <change afterPath="$PROJECT_DIR$/src/app/User/Application/Factory/RegisterUserDtoFactory.php" afterDir="false" />
       <change beforePath="$PROJECT_DIR$/.idea/workspace.xml" beforeDir="false" afterPath="$PROJECT_DIR$/.idea/workspace.xml" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/src/app/Common/Domain/Userid.php" beforeDir="false" afterPath="$PROJECT_DIR$/src/app/Common/Domain/UserId.php" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/src/app/User/Application/ApplicationTest/RegisterUserCommandFactoryTest.php" beforeDir="false" afterPath="$PROJECT_DIR$/src/app/User/Application/ApplicationTest/RegisterUserCommandFactoryTest.php" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/src/app/User/Application/Factory/RegisterUserFactory.php" beforeDir="false" afterPath="$PROJECT_DIR$/src/app/User/Application/Factory/RegisterUserCommandFactory.php" afterDir="false" />
     </list>
     <option name="SHOW_DIALOG" value="false" />
     <option name="HIGHLIGHT_CONFLICTS" value="true" />
@@ -162,9 +156,10 @@
   </component>
   <component name="PropertiesComponent"><![CDATA[{
   "keyToString": {
+    "PHPUnit.メイン.executor": "Run",
     "RunOnceActivity.ShowReadmeOnStart": "true",
     "RunOnceActivity.git.unshallow": "true",
-    "git-widget-placeholder": "feature/register-user-application-dto",
+    "git-widget-placeholder": "feature/user-register-application-usecase",
     "node.js.detected.package.eslint": "true",
     "node.js.selected.package.eslint": "(autodetect)",
     "nodejs_package_manager_path": "npm",

--- a/src/app/Common/Domain/UserId.php
+++ b/src/app/Common/Domain/UserId.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace App\Common\Domain;
+
+use InvalidArgumentException;
+
+class UserId
+{
+    private ?int $value;
+
+    public function __construct(?int $value)
+    {
+        if (!is_null($value) && $value <= 0) {
+            throw new InvalidArgumentException('User Id must be a positive integer.');
+        }
+
+        $this->value = $value;
+    }
+
+    public function getValue(): ?int
+    {
+        return $this->value;
+    }
+}

--- a/src/app/User/Application/ApplicationTest/RegisterUserDtoFactoryTest.php
+++ b/src/app/User/Application/ApplicationTest/RegisterUserDtoFactoryTest.php
@@ -2,6 +2,8 @@
 
 namespace App\User\Application\ApplicationTest;
 
+use App\User\Domain\Entity\UserEntity;
+use App\User\Domain\Factory\UserEntityFactory;
 use Tests\TestCase;
 use App\User\Application\Factory\RegisterUserDtoFactory;
 use App\User\Application\Dto\RegisterUserDto;
@@ -29,7 +31,7 @@ class RegisterUserDtoFactoryTest extends TestCase
      */
     public function test1(): void
     {
-        $testData = $this->mockUser();
+        $testData = $this->mockEntity();
         $result = RegisterUserDtoFactory::build($testData);
 
         $this->assertInstanceOf(RegisterUserDto::class, $result);
@@ -41,7 +43,7 @@ class RegisterUserDtoFactoryTest extends TestCase
      */
     public function test2(): void
     {
-        $testData = $this->mockUser();
+        $testData = $this->mockEntity();
         $result = RegisterUserDtoFactory::build($testData);
 
         $this->assertEquals($result->id, new UserId($this->arrayRequestData()['id']));
@@ -54,27 +56,65 @@ class RegisterUserDtoFactoryTest extends TestCase
         $this->assertEquals($result->profileImage, $this->arrayRequestData()['profile_image']);
     }
 
-    private function mockUser(): User
+    private function mockEntity(): UserEntity
     {
-        $mockUser = Mockery::mock(User::class);
+        $factory = Mockery::mock(
+            'alias'. UserEntityFactory::class
+        );
 
-        $mockUser
-            ->shouldReceive('toArray')
-            ->andReturn($this->arrayRequestData());
+        $entity = Mockery::mock(
+            UserEntity::class
+        );
 
-        return $mockUser;
+        $factory
+            ->shouldReceive('build')
+            ->andReturn($entity);
+
+        $entity
+            ->shouldReceive('getUserId')
+            ->andReturn(new UserId($this->arrayRequestData()['id']));
+
+        $entity
+            ->shouldReceive('getFirstName')
+            ->andReturn($this->arrayRequestData()['first_name']);
+
+        $entity
+            ->shouldReceive('getLastName')
+            ->andReturn($this->arrayRequestData()['last_name']);
+
+        $entity
+            ->shouldReceive('getEmail')
+            ->andReturn(new Email($this->arrayRequestData()['email']));
+
+        $entity
+            ->shouldReceive('getBio')
+            ->andReturn($this->arrayRequestData()['bio']);
+
+        $entity
+            ->shouldReceive('getLocation')
+            ->andReturn($this->arrayRequestData()['location']);
+
+        $entity
+            ->shouldReceive('getSkills')
+            ->andReturn(json_decode($this->arrayRequestData()['skills'], true));
+
+        $entity
+            ->shouldReceive('getProfileImage')
+            ->andReturn($this->arrayRequestData()['profile_image']);
+
+        return $entity;
     }
 
     private function arrayRequestData(): array
     {
         return [
             'id' => 1,
-            'first_name' => 'Zlatan',
-            'last_name' => 'Ibrahimovic',
-            'email' => 'ac-milan@test.com',
+            'first_name' => 'Cristiano',
+            'last_name' => 'Ronaldo',
             'bio' => 'I am a football player',
-            'location' => 'Milan',
+            'email' => 'manchester-united@test.com',
             'skills' => json_encode(['Laravel', 'React']),
+            'location' => 'Manchester',
             'profile_image' => 'https://example.com/profile.jpg',
         ];
     }

--- a/src/app/User/Application/ApplicationTest/RegisterUserUseCaseTest.php
+++ b/src/app/User/Application/ApplicationTest/RegisterUserUseCaseTest.php
@@ -1,0 +1,171 @@
+<?php
+
+namespace App\User\Application\ApplicationTest;
+
+use App\User\Application\UseCase\RegisterUserUsecase;
+use App\User\Infrastructure\Repository\UserRepository;
+use App\User\Domain\Factory\UserEntityFactory;
+use App\User\Application\Dto\RegisterUserDto;
+use App\User\Application\Factory\RegisterUserDtoFactory;
+use App\User\Application\UseCommand\RegisterUserCommand;
+use App\User\Application\Factory\RegisterUserCommandFactory;
+use App\User\Domain\Entity\UserEntity;
+use Tests\TestCase;
+use Mockery;
+use App\Common\Domain\UserId;
+use App\User\Domain\ValueObject\Email;
+use App\User\Domain\RepositoryInterface\PasswordHasherInterface;
+
+class RegisterUserUseCaseTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+    }
+
+    protected function tearDown(): void
+    {
+        parent::tearDown();
+    }
+
+    private function mockCommand(): RegisterUserCommand
+    {
+       $factory = Mockery::mock(
+           'alias' . RegisterUserCommandFactory::class
+       );
+
+       $command = Mockery::mock(RegisterUserCommand::class);
+
+       $factory
+           ->shouldReceive('build')
+           ->andReturn($command);
+
+       $command
+              ->shouldReceive('toArray')
+              ->andReturn($this->arrayRequestData());
+
+         return $command;
+    }
+
+    private function mockEntity(): UserEntity
+    {
+        $factory = Mockery::mock(
+            'alias' . UserEntityFactory::class
+        );
+
+        $entity = Mockery::mock(UserEntity::class);
+
+        $factory
+            ->shouldReceive('build')
+            ->andReturn($entity);
+
+        $entity
+            ->shouldReceive('getUserId')
+            ->andReturn(new UserId($this->arrayRequestData()['id']));
+
+        $entity
+            ->shouldReceive('getFirstName')
+            ->andReturn($this->arrayRequestData()['first_name']);
+
+        $entity
+            ->shouldReceive('getLastName')
+            ->andReturn($this->arrayRequestData()['last_name']);
+
+        $entity
+            ->shouldReceive('getEmail')
+            ->andReturn(new Email($this->arrayRequestData()['email']));
+
+        $entity
+            ->shouldReceive('getBio')
+            ->andReturn($this->arrayRequestData()['bio']);
+
+        $entity
+            ->shouldReceive('getLocation')
+            ->andReturn($this->arrayRequestData()['location']);
+
+        $entity
+            ->shouldReceive('getSkills')
+            ->andReturn($this->arrayRequestData()['skills']);
+
+        $entity
+            ->shouldReceive('getProfileImage')
+            ->andReturn($this->arrayRequestData()['profile_image']);
+
+        return $entity;
+    }
+
+    private function mockDto(): RegisterUserDto
+    {
+        $factory = Mockery::mock(
+            'alias' . RegisterUserDtoFactory::class
+        );
+
+        $dto = Mockery::mock(RegisterUserDto::class);
+
+        $factory
+            ->shouldReceive('build')
+            ->andReturn($dto);
+
+        $dto
+            ->shouldReceive('toArray')
+            ->andReturn($this->arrayRequestData());
+
+        return $dto;
+    }
+
+    private function mockRepository(): UserRepository
+    {
+        $repository = Mockery::mock(UserRepository::class);
+
+        $repository
+            ->shouldReceive('save')
+            ->andReturn($this->mockEntity());
+
+        return $repository;
+    }
+
+    private function mockPasswordHasher(): PasswordHasherInterface
+    {
+        $hasher = Mockery::mock(PasswordHasherInterface::class);
+
+        $hasher
+            ->shouldReceive('hash')
+            ->andReturn($this->arrayRequestData()['password']);
+
+        return $hasher;
+    }
+
+
+    private function arrayRequestData(): array
+    {
+       return [
+           'id' => 1,
+           'first_name' => 'Cristiano',
+           'last_name' => 'Ronaldo',
+           'email' => 'cristiano-ronaldo@test.com',
+           'password' => 'test1234',
+           'bio' => 'I am a football player',
+           'location' => 'Manchester',
+           'skills' => ['Laravel', 'React'],
+           'profile_image' => 'https://example.com/profile.jpg',
+       ];
+    }
+
+    /**
+     * @test
+     * @testdox RegisterUserUseCaseTest_build_successfully check type
+     */
+    public function test(): void
+    {
+        $usecase = new RegisterUserUsecase(
+            $this->mockRepository(),
+            $this->mockPasswordHasher()
+        );
+
+        $result = $usecase->handle(
+            $this->mockCommand(),
+        );
+
+        $this->assertInstanceOf(RegisterUserDto::class, $result);
+    }
+}

--- a/src/app/User/Application/Factory/RegisterUserCommandFactory.php
+++ b/src/app/User/Application/Factory/RegisterUserCommandFactory.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace App\User\Application\Factory;
+
+use App\User\Application\UseCommand\RegisterUserCommand;
+use Illuminate\Http\Client\Request;
+use InvalidArgumentException;
+
+class RegisterUserCommandFactory
+{
+    public static function build(Request $request): RegisterUserCommand
+    {
+        $requestArray = $request->toArray();
+
+        self::validate($requestArray);
+
+        return new RegisterUserCommand(
+            $requestArray['first_name'],
+            $requestArray['last_name'],
+            $requestArray['email'],
+            $requestArray['password'],
+            $requestArray['bio'] ?? null,
+            $requestArray['location'] ?? null,
+            is_string($requestArray['skills'])
+                ? json_decode($requestArray['skills'], true)
+                : (is_array($requestArray['skills']) ? $requestArray['skills'] : []),
+            $requestArray['profile_image'] ?? null,
+        );
+    }
+
+    private static $properties = [
+        'first_name',
+        'last_name',
+        'email',
+        'password',
+        'bio',
+        'location',
+        'skills',
+        'profile_image'
+    ];
+
+    private static function validate(array $request): void
+    {
+        foreach (self::$properties as $property) {
+            if (!array_key_exists($property, $request)) {
+                throw new InvalidArgumentException("Missing required property: {$property}");
+            }
+        }
+    }
+}

--- a/src/app/User/Application/Factory/RegisterUserDtoFactory.php
+++ b/src/app/User/Application/Factory/RegisterUserDtoFactory.php
@@ -2,28 +2,24 @@
 
 namespace App\User\Application\Factory;
 
-use App\Models\User;
+use App\User\Domain\Entity\UserEntity;
 use App\User\Domain\ValueObject\Email;
 use App\Common\Domain\UserId;
 use App\User\Application\Dto\RegisterUserDto;
 
 class RegisterUserDtoFactory
 {
-    public static function build(User $user): RegisterUserDto
+    public static function build(UserEntity $entity): RegisterUserDto
     {
-        $resultArray = $user->toArray();
-
         return new RegisterUserDto(
-            new UserId($resultArray['id']),
-            $resultArray['first_name'],
-            $resultArray['last_name'],
-            new Email($resultArray['email']),
-            $resultArray['bio'] ?? null,
-            $resultArray['location'] ?? null,
-            is_string($resultArray['skills'])
-                ? json_decode($resultArray['skills'], true)
-                : (is_array($resultArray['skills']) ? $resultArray['skills'] : []),
-            $resultArray['profile_image'] ?? null,
+            new UserId($entity->getUserId()?->getValue()),
+            $entity->getFirstName(),
+            $entity->getLastName(),
+            new Email($entity->getEmail()->getValue()),
+            $entity->getBio(),
+            $entity->getLocation(),
+            $entity->getSkills(),
+            $entity->getProfileImage(),
         );
     }
 }

--- a/src/app/User/Application/UseCase/RegisterUserUsecase.php
+++ b/src/app/User/Application/UseCase/RegisterUserUsecase.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace App\User\Application\UseCase;
+
+use App\User\Application\Dto\RegisterUserDto;
+use App\User\Application\UseCommand\RegisterUserCommand;
+use App\User\Domain\RepositoryInterface\PasswordHasherInterface;
+use App\User\Domain\RepositoryInterface\UserRepositoryInterface;
+use App\User\Domain\Factory\UserEntityFactory;
+use App\User\Application\Factory\RegisterUserDtoFactory;
+
+class RegisterUserUsecase
+{
+    public function __construct(
+        readonly private UserRepositoryInterface $repository,
+        readonly private PasswordHasherInterface $passwordHasher,
+    ) {
+    }
+
+    public function handle(
+        RegisterUserCommand $command
+    ): RegisterUserDto
+    {
+        $userEntity = UserEntityFactory::build(
+            $command->toArray(),
+            $this->passwordHasher,
+        );
+
+        $result = $this->repository->save($userEntity);
+
+        return RegisterUserDtoFactory::build($result);
+    }
+}


### PR DESCRIPTION
## Description

This pull request introduces the `RegisterUserUsecase`, which orchestrates the process of registering a new user by:

- Accepting a `RegisterUserCommand` containing validated and structured user input
- Building a domain `UserEntity` using `UserEntityFactory`
- Persisting the entity through `UserRepositoryInterface`
- Returning a `RegisterUserDto` via `RegisterUserDtoFactory` for presentation layer consumption

This use case sits entirely within the Application layer and strictly depends on interfaces and factories to maintain separation of concerns and testability.