### PR TITLE
Connect RegisterUserViewModel with UserController to complete user registration response pipeline

### DIFF
--- a/.idea/workspace.xml
+++ b/.idea/workspace.xml
@@ -5,11 +5,8 @@
   </component>
   <component name="ChangeListManager">
     <list default="true" id="6952a861-17ec-40ad-b866-c564752c14a8" name="変更" comment="">
-      <change afterPath="$PROJECT_DIR$/src/app/User/Presentation/PresentationTest/RegisterUserViewModelFactoryTest.php" afterDir="false" />
-      <change afterPath="$PROJECT_DIR$/src/app/User/Presentation/ViewModel/Factory/RegisterUserViewModelFactory.php" afterDir="false" />
-      <change afterPath="$PROJECT_DIR$/src/app/User/Presentation/ViewModel/RegisterUserViewModel.php" afterDir="false" />
       <change beforePath="$PROJECT_DIR$/.idea/workspace.xml" beforeDir="false" afterPath="$PROJECT_DIR$/.idea/workspace.xml" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/src/app/User/Application/Dto/RegisterUserDto.php" beforeDir="false" afterPath="$PROJECT_DIR$/src/app/User/Application/Dto/RegisterUserDto.php" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/app/User/Presentation/Controller/UserController.php" beforeDir="false" afterPath="$PROJECT_DIR$/src/app/User/Presentation/Controller/UserController.php" afterDir="false" />
     </list>
     <option name="SHOW_DIALOG" value="false" />
     <option name="HIGHLIGHT_CONFLICTS" value="true" />
@@ -163,7 +160,7 @@
     "PHPUnit.メイン.executor": "Run",
     "RunOnceActivity.ShowReadmeOnStart": "true",
     "RunOnceActivity.git.unshallow": "true",
-    "git-widget-placeholder": "feature/user-register-presentation-viewmodel",
+    "git-widget-placeholder": "feature/register-user-presentation-controller",
     "node.js.detected.package.eslint": "true",
     "node.js.selected.package.eslint": "(autodetect)",
     "nodejs_package_manager_path": "npm",

--- a/.idea/workspace.xml
+++ b/.idea/workspace.xml
@@ -5,7 +5,11 @@
   </component>
   <component name="ChangeListManager">
     <list default="true" id="6952a861-17ec-40ad-b866-c564752c14a8" name="変更" comment="">
+      <change afterPath="$PROJECT_DIR$/src/app/User/Presentation/PresentationTest/RegisterUserViewModelFactoryTest.php" afterDir="false" />
+      <change afterPath="$PROJECT_DIR$/src/app/User/Presentation/ViewModel/Factory/RegisterUserViewModelFactory.php" afterDir="false" />
+      <change afterPath="$PROJECT_DIR$/src/app/User/Presentation/ViewModel/RegisterUserViewModel.php" afterDir="false" />
       <change beforePath="$PROJECT_DIR$/.idea/workspace.xml" beforeDir="false" afterPath="$PROJECT_DIR$/.idea/workspace.xml" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/app/User/Application/Dto/RegisterUserDto.php" beforeDir="false" afterPath="$PROJECT_DIR$/src/app/User/Application/Dto/RegisterUserDto.php" afterDir="false" />
     </list>
     <option name="SHOW_DIALOG" value="false" />
     <option name="HIGHLIGHT_CONFLICTS" value="true" />
@@ -159,7 +163,7 @@
     "PHPUnit.メイン.executor": "Run",
     "RunOnceActivity.ShowReadmeOnStart": "true",
     "RunOnceActivity.git.unshallow": "true",
-    "git-widget-placeholder": "feature/user-register-application-usecase",
+    "git-widget-placeholder": "feature/user-register-presentation-viewmodel",
     "node.js.detected.package.eslint": "true",
     "node.js.selected.package.eslint": "(autodetect)",
     "nodejs_package_manager_path": "npm",

--- a/src/app/User/Application/ApplicationTest/RegisterUserCommandFactoryTest.php
+++ b/src/app/User/Application/ApplicationTest/RegisterUserCommandFactoryTest.php
@@ -2,7 +2,7 @@
 
 namespace  App\User\Application\ApplicationTest;
 
-use \Illuminate\Http\Client\Request;
+use \Illuminate\Http\Request;
 use Tests\TestCase;
 use Mockery;
 use App\User\Application\Factory\RegisterUserCommandFactory;

--- a/src/app/User/Application/Dto/RegisterUserDto.php
+++ b/src/app/User/Application/Dto/RegisterUserDto.php
@@ -20,10 +20,50 @@ class RegisterUserDto
 
     }
 
+    public function getId(): UserId
+    {
+        return $this->id;
+    }
+
+    public function getFirstName(): string
+    {
+        return $this->firstName;
+    }
+
+    public function getLastName(): string
+    {
+        return $this->lastName;
+    }
+
+    public function getEmail(): Email
+    {
+        return $this->email;
+    }
+
+    public function getBio(): string
+    {
+        return $this->bio ?? '';
+    }
+
+    public function getLocation(): string
+    {
+        return $this->location ?? '';
+    }
+
+    public function getSkills(): array
+    {
+        return $this->skills;
+    }
+
+    public function getProfileImage(): string
+    {
+        return $this->profileImage ?? '';
+    }
+
     public function toArray(): array
     {
         return [
-            'id' => $this->id->getUserId(),
+            'id' => $this->id->getValue(),
             'first_name' => $this->firstName,
             'last_name' => $this->lastName,
             'email' => $this->email->getValue(),

--- a/src/app/User/Application/Factory/RegisterUserCommandFactory.php
+++ b/src/app/User/Application/Factory/RegisterUserCommandFactory.php
@@ -3,7 +3,7 @@
 namespace App\User\Application\Factory;
 
 use App\User\Application\UseCommand\RegisterUserCommand;
-use Illuminate\Http\Client\Request;
+use Illuminate\Http\Request;
 use InvalidArgumentException;
 
 class RegisterUserCommandFactory

--- a/src/app/User/Presentation/Controller/UserController.php
+++ b/src/app/User/Presentation/Controller/UserController.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace App\User\Presentation\Controller;
+
+use App\Http\Controllers\Controller;
+use App\User\Application\Factory\RegisterUserCommandFactory;
+use App\User\Presentation\ViewModel\Factory\RegisterUserViewModelFactory;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+use App\User\Application\UseCase\RegisterUserUsecase;
+use Illuminate\Support\Facades\DB;
+use Exception;
+
+class UserController extends Controller
+{
+    public function createUser(
+        Request $request,
+        RegisterUserUsecase $useCase
+    ): JsonResponse
+    {
+        DB::connection('mysql')->beginTransaction();
+
+        try {
+            $command = RegisterUserCommandFactory::build($request);
+
+            $dto = $useCase->handle($command);
+
+            DB::connection('mysql')->commit();
+
+            return response()->json([
+                'status' => 'success',
+                'data' => RegisterUserViewModelFactory::build($dto),
+            ], 201);
+        } catch (Exception $e) {
+            DB::connection('mysql')->rollBack();
+
+            return response()->json([
+                'status' => 'error',
+                'message' => $e->getMessage(),
+            ], 500);
+        }
+    }
+}

--- a/src/app/User/Presentation/PresentationTest/Controller/UserController_registerTest.php
+++ b/src/app/User/Presentation/PresentationTest/Controller/UserController_registerTest.php
@@ -1,0 +1,175 @@
+<?php
+
+namespace App\User\Presentation\PresentationTest\Controller;
+
+use App\Common\Domain\UserId;
+use App\User\Application\UseCase\RegisterUserUsecase;
+use App\User\Application\UseCommand\RegisterUserCommand;
+use App\User\Presentation\Controller\UserController;
+use App\User\Application\Dto\RegisterUserDto;
+use Illuminate\Http\Request;
+use App\User\Domain\ValueObject\Email;
+use Tests\TestCase;
+use Mockery;
+
+class UserController_registerTest extends TestCase
+{
+    private UserController $controller;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->controller = new UserController();
+    }
+
+    protected function tearDown(): void
+    {
+        parent::tearDown();
+    }
+
+    /**
+     * @test
+     * @testdox UserController_registerTest_successfully
+     */
+    public function test1(): void
+    {
+        $request = $this->mockRequest();
+        $useCase = $this->mockUseCase();
+        $this->mockCommand();
+
+        $response = $this->controller->createUser($request, $useCase);
+
+        $this->assertEquals(201, $response->getStatusCode());
+        $this->assertEquals('success', json_decode($response->getContent())->status);
+    }
+
+    private function mockRequest(): Request
+    {
+        $request = Mockery::mock(Request::class);
+
+        $request
+            ->shouldReceive('toArray')
+            ->andReturn($this->arrayTestData());
+
+        return $request;
+    }
+
+    private function mockCommand(): RegisterUserCommand
+    {
+        $factory = Mockery::mock(
+            'alias'. RegisterUserCommand::class
+        );
+
+        $command = Mockery::mock(RegisterUserCommand::class);
+
+        $factory
+            ->shouldReceive('build')
+            ->andReturn($command);
+
+        $command
+            ->shouldReceive('getFirstName')
+            ->andReturn($this->arrayTestData()['first_name']);
+
+        $command
+            ->shouldReceive('getLastName')
+            ->andReturn($this->arrayTestData()['last_name']);
+
+        $command
+            ->shouldReceive('getEmail')
+            ->andReturn($this->arrayTestData()['email']);
+
+        $command
+            ->shouldReceive('getPassword')
+            ->andReturn($this->arrayTestData()['password']);
+
+        $command
+            ->shouldReceive('getBio')
+            ->andReturn($this->arrayTestData()['bio']);
+
+        $command
+            ->shouldReceive('getLocation')
+            ->andReturn($this->arrayTestData()['location']);
+
+        $command
+            ->shouldReceive('getSkills')
+            ->andReturn($this->arrayTestData()['skills']);
+
+        $command
+            ->shouldReceive('getProfileImage')
+            ->andReturn($this->arrayTestData()['profile_image']);
+
+        return $command;
+    }
+
+    private function mockUseCase(): RegisterUserUsecase
+    {
+        $useCase = Mockery::mock(RegisterUserUsecase::class);
+
+        $useCase
+            ->shouldReceive('handle')
+            ->andReturn($this->mockDto());
+
+        return $useCase;
+    }
+
+    private function mockDto(): RegisterUserDto
+    {
+        $factory = Mockery::mock(
+            'alias'. RegisterUserDto::class
+        );
+
+        $dto = Mockery::mock(RegisterUserDto::class);
+
+        $factory
+            ->shouldReceive('build')
+            ->andReturn($dto);
+
+        $dto
+            ->shouldReceive('getId')
+            ->andReturn(new UserId(1));
+
+        $dto
+            ->shouldReceive('getFirstName')
+            ->andReturn($this->arrayTestData()['first_name']);
+
+        $dto
+            ->shouldReceive('getLastName')
+            ->andReturn($this->arrayTestData()['last_name']);
+
+        $dto
+            ->shouldReceive('getEmail')
+            ->andReturn(new Email($this->arrayTestData()['email']));
+
+        $dto
+            ->shouldReceive('getBio')
+            ->andReturn($this->arrayTestData()['bio']);
+
+        $dto
+            ->shouldReceive('getLocation')
+            ->andReturn($this->arrayTestData()['location']);
+
+        $dto
+            ->shouldReceive('getSkills')
+            ->andReturn($this->arrayTestData()['skills']);
+
+        $dto
+            ->shouldReceive('getProfileImage')
+            ->andReturn($this->arrayTestData()['profile_image']);
+
+        return $dto;
+    }
+
+    private function arrayTestData(): array
+    {
+        return [
+            'first_name' => 'Cristiano',
+            'last_name' => 'Ronaldo',
+            'email' => 'manchester7@test.com',
+            'password' => 'test1234',
+            'bio' => 'I am a football player',
+            'location' => 'Manchester',
+            'skills' => ['Laravel', 'React'],
+            'profile_image' => 'https://example.com/profile.jpg',
+        ];
+    }
+}

--- a/src/app/User/Presentation/PresentationTest/RegisterUserViewModelFactoryTest.php
+++ b/src/app/User/Presentation/PresentationTest/RegisterUserViewModelFactoryTest.php
@@ -1,0 +1,117 @@
+<?php
+
+namespace App\User\Presentation\PresentationTest;
+
+use App\User\Application\Dto\RegisterUserDto;
+use Tests\TestCase;
+use App\User\Presentation\ViewModel\Factory\RegisterUserViewModelFactory;
+use Mockery;
+use App\User\Application\Factory\RegisterUserDtoFactory;
+use App\User\Presentation\ViewModel\RegisterUserViewModel;
+use App\Common\Domain\UserId;
+use App\User\Domain\ValueObject\Email;
+
+class RegisterUserViewModelFactoryTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+    }
+
+    protected function tearDown(): void
+    {
+        parent::tearDown();
+    }
+
+    private function mockDto(): RegisterUserDto
+    {
+        $factory = Mockery::mock(
+            'alias'. RegisterUserDtoFactory::class
+        );
+
+        $dto = Mockery::mock(RegisterUserDto::class);
+
+        $factory
+            ->shouldReceive('build')
+            ->andReturn($dto);
+
+        $dto
+            ->shouldReceive('getId')
+            ->andReturn(new UserId($this->arrayRequestData()['id']));
+
+        $dto
+            ->shouldReceive('getFirstName')
+            ->andReturn($this->arrayRequestData()['first_name']);
+
+        $dto
+            ->shouldReceive('getLastName')
+            ->andReturn($this->arrayRequestData()['last_name']);
+
+        $dto
+            ->shouldReceive('getEmail')
+            ->andReturn(new Email($this->arrayRequestData()['email']));
+
+        $dto
+            ->shouldReceive('getBio')
+            ->andReturn($this->arrayRequestData()['bio']);
+
+        $dto
+            ->shouldReceive('getLocation')
+            ->andReturn($this->arrayRequestData()['location']);
+
+        $dto
+            ->shouldReceive('getSkills')
+            ->andReturn($this->arrayRequestData()['skills']);
+
+        $dto
+            ->shouldReceive('getProfileImage')
+            ->andReturn($this->arrayRequestData()['profile_image']);
+
+        return $dto;
+    }
+
+    private function arrayRequestData(): array
+    {
+        return [
+            'id' => 1,
+            'first_name' => 'Cristiano',
+            'last_name' => 'Ronaldo',
+            'email' => 'manchester7@test.com',
+            'bio' => 'I am a football player',
+            'location' => 'Manchester',
+            'skills' => ['Laravel', 'React'],
+            'profile_image' => 'https://example.com/profile.jpg',
+        ];
+    }
+
+    /**
+     * @test
+     * @testdox RegisterUserViewModelFactory_build_successfully
+     */
+    public function test1(): void
+    {
+        $dto = $this->mockDto();
+        $result = RegisterUserViewModelFactory::build($dto);
+
+        $this->assertInstanceOf(RegisterUserViewModel::class, $result);
+    }
+
+    /**
+     * @test
+     * @testdox RegisterUserViewModelFactory_build_successfully check value
+     */
+    public function test2(): void
+    {
+        $dto = $this->mockDto();
+        $result = RegisterUserViewModelFactory::build($dto);
+
+        $this->assertEquals($this->arrayRequestData()['id'], $result->toArray()['id']);
+        $this->assertEquals($this->arrayRequestData()['first_name'], $result->toArray()['first_name']);
+        $this->assertEquals($this->arrayRequestData()['last_name'], $result->toArray()['last_name']);
+        $this->assertEquals($this->arrayRequestData()['email'], $result->toArray()['email']);
+        $this->assertEquals($this->arrayRequestData()['bio'], $result->toArray()['bio']);
+        $this->assertEquals($this->arrayRequestData()['location'], $result->toArray()['location']);
+        $this->assertEquals($this->arrayRequestData()['skills'], json_decode($result->toArray()['skills'], true));
+        $this->assertEquals($this->arrayRequestData()['profile_image'], $result->toArray()['profile_image']);
+    }
+}

--- a/src/app/User/Presentation/ViewModel/Factory/RegisterUserViewModelFactory.php
+++ b/src/app/User/Presentation/ViewModel/Factory/RegisterUserViewModelFactory.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace App\User\Presentation\ViewModel\Factory;
+
+use App\User\Application\Dto\RegisterUserDto;
+use App\User\Presentation\ViewModel\RegisterUserViewModel;
+
+class RegisterUserViewModelFactory
+{
+    public static function build(
+        RegisterUserDto $dto
+    ): RegisterUserViewModel
+    {
+        return new RegisterUserViewModel($dto);
+    }
+}

--- a/src/app/User/Presentation/ViewModel/RegisterUserViewModel.php
+++ b/src/app/User/Presentation/ViewModel/RegisterUserViewModel.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace App\User\Presentation\ViewModel;
+
+use App\User\Application\Dto\RegisterUserDto;
+
+class RegisterUserViewModel
+{
+    private int $id;
+    private string $firstName;
+    private string $lastName;
+    private string $email;
+    private string $bio;
+    private string $location;
+    private array $skills;
+    private string $profileImage;
+
+    public function __construct(RegisterUserDto $dto)
+    {
+        $this->id = $dto->getId()->getValue();
+        $this->firstName = $dto->getFirstName();
+        $this->lastName = $dto->getLastName();
+        $this->email = $dto->getEmail()->getValue();
+        $this->bio = $dto->getBio() ?? '';
+        $this->location = $dto->getLocation() ?? '';
+        $this->skills = $dto->getSkills();
+        $this->profileImage = $dto->getProfileImage() ?? '';
+    }
+
+    public function toArray(): array
+    {
+        return [
+            'id' => $this->id,
+            'first_name' => $this->firstName,
+            'last_name' => $this->lastName,
+            'email' => $this->email,
+            'bio' => $this->bio,
+            'location' => $this->location,
+            'skills' => json_encode($this->skills),
+            'profile_image' => $this->profileImage
+        ];
+    }
+}


### PR DESCRIPTION
### ✅ Description

This pull request integrates the previously implemented `RegisterUserViewModel` into the `UserController::createUser` method. This closes the response pipeline loop for user registration by ensuring structured, presentation-layer-specific response formatting.

Included in this PR:

- The controller now uses `RegisterUserViewModelFactory` to transform the DTO returned from the use case.
- The resulting ViewModel is serialised into the API response (`JsonResponse`) with HTTP 201.
- Transaction handling is safely managed with `try-catch` logic, and `commit()` is executed only upon successful logic flow.