### PR TITLE
Add `ShowUserDto` to encapsulate user profile data for application layer

### DIFF
--- a/.idea/workspace.xml
+++ b/.idea/workspace.xml
@@ -5,9 +5,9 @@
   </component>
   <component name="ChangeListManager">
     <list default="true" id="6952a861-17ec-40ad-b866-c564752c14a8" name="変更" comment="fix: test-environment-fix">
+      <change afterPath="$PROJECT_DIR$/src/app/User/Application/ApplicationTest/ShowUserDtoTest.php" afterDir="false" />
+      <change afterPath="$PROJECT_DIR$/src/app/User/Application/Dto/ShowUserDto.php" afterDir="false" />
       <change beforePath="$PROJECT_DIR$/.idea/workspace.xml" beforeDir="false" afterPath="$PROJECT_DIR$/.idea/workspace.xml" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/src/app/User/Infrastructure/InfrastructureTest/UserRepositoryTest.php" beforeDir="false" />
-      <change beforePath="$PROJECT_DIR$/src/app/User/Infrastructure/Repository/UserRepository.php" beforeDir="false" afterPath="$PROJECT_DIR$/src/app/User/Infrastructure/Repository/UserRepository.php" afterDir="false" />
     </list>
     <option name="SHOW_DIALOG" value="false" />
     <option name="HIGHLIGHT_CONFLICTS" value="true" />
@@ -162,7 +162,7 @@
     "PHPUnit.メイン.executor": "Run",
     "RunOnceActivity.ShowReadmeOnStart": "true",
     "RunOnceActivity.git.unshallow": "true",
-    "git-widget-placeholder": "feature/show-user-repository-add",
+    "git-widget-placeholder": "feature/show-user-application-dto",
     "node.js.detected.package.eslint": "true",
     "node.js.selected.package.eslint": "(autodetect)",
     "nodejs_package_manager_path": "npm",

--- a/src/app/User/Application/ApplicationTest/ShowUserDtoTest.php
+++ b/src/app/User/Application/ApplicationTest/ShowUserDtoTest.php
@@ -1,0 +1,116 @@
+<?php
+
+namespace App\User\Application\ApplicationTest;
+
+use App\Common\Domain\UserId;
+use App\User\Application\Dto\ShowUserDto;
+use App\User\Domain\Entity\UserEntity;
+use App\User\Domain\Factory\UserFromModelEntityFactory;
+use Tests\TestCase;
+use App\User\Domain\ValueObject\Email;
+use Mockery;
+
+class ShowUserDtoTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+    }
+
+    protected function tearDown(): void
+    {
+        parent::tearDown();
+    }
+
+    private function mockData(): array
+    {
+        return [
+            'id' => 1,
+            'first_name' => 'xabi',
+            'last_name' => 'alonso',
+            'bio' => 'I am a football player',
+            'email' => 'real-madrid14@test.com',
+            'location' => 'Spain',
+            'skills' => json_encode(['football', 'coaching']),
+            'profile_image' => 'https://example.com/image.jpg',
+        ];
+    }
+
+    private function mockEntity(): UserEntity
+    {
+        $factory = Mockery::mock(
+            'alias' . UserFromModelEntityFactory::class
+        );
+
+        $entity = Mockery::mock(UserEntity::class);
+
+        $factory
+            ->shouldReceive('buildFromModel')
+            ->andReturn($entity);
+
+        $entity
+            ->shouldReceive('getUserId')
+            ->andReturn(new UserId($this->mockData()['id']));
+
+        $entity
+            ->shouldReceive('getFirstName')
+            ->andReturn($this->mockData()['first_name']);
+
+        $entity
+            ->shouldReceive('getLastName')
+            ->andReturn($this->mockData()['last_name']);
+
+        $entity
+            ->shouldReceive('getBio')
+            ->andReturn($this->mockData()['bio']);
+
+        $entity
+            ->shouldReceive('getEmail')
+            ->andReturn(new Email($this->mockData()['email']));
+
+        $entity
+            ->shouldReceive('getLocation')
+            ->andReturn($this->mockData()['location']);
+
+        $entity
+            ->shouldReceive('getSkills')
+            ->andReturn(json_decode($this->mockData()['skills'], true));
+
+        $entity
+            ->shouldReceive('getProfileImage')
+            ->andReturn($this->mockData()['profile_image']);
+
+        return  $entity;
+    }
+
+    /**
+     * @test
+     * @testdox ShowUserDtoTest_build_successfully check type
+     */
+    public function test1(): void
+    {
+        $result = ShowUserDto::build(
+            $this->mockEntity()
+        );
+        $this->assertInstanceOf(ShowUserDto::class, $result);
+    }
+
+    /**
+     * @test
+     * @testdox ShowUserDtoTest_build_successfully check value
+     */
+    public function test2(): void
+    {
+        $result = ShowUserDto::build(
+            $this->mockEntity()
+        );
+
+        $this->assertEquals($result->id, new UserId($this->mockData()['id']));
+        $this->assertEquals($result->firstName, $this->mockData()['first_name']);
+        $this->assertEquals($result->lastName, $this->mockData()['last_name']);
+        $this->assertEquals($result->bio, $this->mockData()['bio']);
+        $this->assertEquals($result->location, $this->mockData()['location']);
+        $this->assertEquals($result->skills, json_decode($this->mockData()['skills'], true));
+        $this->assertEquals($result->profileImage, $this->mockData()['profile_image']);
+    }
+}

--- a/src/app/User/Application/Dto/ShowUserDto.php
+++ b/src/app/User/Application/Dto/ShowUserDto.php
@@ -1,0 +1,78 @@
+<?php
+
+namespace App\User\Application\Dto;
+
+use App\Common\Domain\UserId;
+use App\User\Domain\Entity\UserEntity;
+use App\User\Domain\ValueObject\Email;
+
+class ShowUserDto
+{
+    public function __construct(
+        public readonly UserId $id,
+        public readonly string $firstName,
+        public readonly string $lastName,
+        public readonly Email $email,
+        public readonly ?string $bio,
+        public readonly ?string $location,
+        public readonly array $skills,
+        public readonly ?string $profileImage
+    ) {
+    }
+
+    public function getId(): UserId
+    {
+        return $this->id;
+    }
+
+    public function getFirstName(): string
+    {
+        return $this->firstName;
+    }
+
+    public function getLastName(): string
+    {
+        return $this->lastName;
+    }
+
+    public function getEmail(): Email
+    {
+        return $this->email;
+    }
+
+    public function getBio(): ?string
+    {
+        return $this->bio ?? null;
+    }
+
+    public function getLocation(): ?string
+    {
+        return $this->location ?? null;
+    }
+
+    public function getSkills(): array
+    {
+        return $this->skills;
+    }
+
+    public function getProfileImage(): ?string
+    {
+        return $this->profileImage ?? null;
+    }
+
+    public static function build(
+        UserEntity $entity
+    ): self
+    {
+        return new self(
+            id: new UserId($entity->getUserId()->getValue()),
+            firstName: $entity->getFirstName(),
+            lastName: $entity->getLastName(),
+            email: $entity->getEmail(),
+            bio: $entity->getBio(),
+            location: $entity->getLocation(),
+            skills: $entity->getSkills(),
+            profileImage: $entity->getProfileImage()
+        );
+    }
+}


### PR DESCRIPTION
### Overview

This pull request introduces the `ShowUserDto` class within the application layer to represent user profile data in a structured and immutable format.

### Details

- The DTO encapsulates user attributes required for the "Show User Profile" use case.
- Includes support for domain value objects such as `UserId` and `Email`.
- Provides typed accessor methods for all properties.
- Implements a static `build()` method for constructing the DTO from a `UserEntity`.

### Motivation

The introduction of this DTO supports clean separation between domain entities and output data structures. This allows the application layer to return fully-formed, serialisable representations of user profile data without leaking domain internals.