### PR TITLE
Implement `ShowUserUseCase` to retrieve user profile by identifier

### DIFF
--- a/.idea/workspace.xml
+++ b/.idea/workspace.xml
@@ -5,9 +5,11 @@
   </component>
   <component name="ChangeListManager">
     <list default="true" id="6952a861-17ec-40ad-b866-c564752c14a8" name="変更" comment="fix: test-environment-fix">
-      <change afterPath="$PROJECT_DIR$/src/app/User/Application/ApplicationTest/ShowUserDtoTest.php" afterDir="false" />
-      <change afterPath="$PROJECT_DIR$/src/app/User/Application/Dto/ShowUserDto.php" afterDir="false" />
       <change beforePath="$PROJECT_DIR$/.idea/workspace.xml" beforeDir="false" afterPath="$PROJECT_DIR$/.idea/workspace.xml" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/app/User/Application/ApplicationTest/RegisterUserUseCaseTest.php" beforeDir="false" afterPath="$PROJECT_DIR$/src/app/User/Application/ApplicationTest/RegisterUserUseCaseTest.php" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/app/User/Application/UseCase/RegisterUserUsecase.php" beforeDir="false" afterPath="$PROJECT_DIR$/src/app/User/Application/UseCase/RegisterUserUseCase.php" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/app/User/Presentation/Controller/UserController.php" beforeDir="false" afterPath="$PROJECT_DIR$/src/app/User/Presentation/Controller/UserController.php" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/app/User/Presentation/PresentationTest/Controller/UserController_registerTest.php" beforeDir="false" afterPath="$PROJECT_DIR$/src/app/User/Presentation/PresentationTest/Controller/UserController_registerTest.php" afterDir="false" />
     </list>
     <option name="SHOW_DIALOG" value="false" />
     <option name="HIGHLIGHT_CONFLICTS" value="true" />
@@ -162,7 +164,7 @@
     "PHPUnit.メイン.executor": "Run",
     "RunOnceActivity.ShowReadmeOnStart": "true",
     "RunOnceActivity.git.unshallow": "true",
-    "git-widget-placeholder": "feature/show-user-application-dto",
+    "git-widget-placeholder": "feature/show-user-application-usecase",
     "node.js.detected.package.eslint": "true",
     "node.js.selected.package.eslint": "(autodetect)",
     "nodejs_package_manager_path": "npm",

--- a/.idea/workspace.xml
+++ b/.idea/workspace.xml
@@ -5,9 +5,9 @@
   </component>
   <component name="ChangeListManager">
     <list default="true" id="6952a861-17ec-40ad-b866-c564752c14a8" name="変更" comment="fix: test-environment-fix">
+      <change afterPath="$PROJECT_DIR$/src/app/User/Application/ApplicationTest/ShowUserDtoTest.php" afterDir="false" />
+      <change afterPath="$PROJECT_DIR$/src/app/User/Application/Dto/ShowUserDto.php" afterDir="false" />
       <change beforePath="$PROJECT_DIR$/.idea/workspace.xml" beforeDir="false" afterPath="$PROJECT_DIR$/.idea/workspace.xml" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/src/app/User/Infrastructure/InfrastructureTest/UserRepositoryTest.php" beforeDir="false" />
-      <change beforePath="$PROJECT_DIR$/src/app/User/Infrastructure/Repository/UserRepository.php" beforeDir="false" afterPath="$PROJECT_DIR$/src/app/User/Infrastructure/Repository/UserRepository.php" afterDir="false" />
     </list>
     <option name="SHOW_DIALOG" value="false" />
     <option name="HIGHLIGHT_CONFLICTS" value="true" />
@@ -162,7 +162,7 @@
     "PHPUnit.メイン.executor": "Run",
     "RunOnceActivity.ShowReadmeOnStart": "true",
     "RunOnceActivity.git.unshallow": "true",
-    "git-widget-placeholder": "feature/show-user-repository-add",
+    "git-widget-placeholder": "feature/show-user-application-dto",
     "node.js.detected.package.eslint": "true",
     "node.js.selected.package.eslint": "(autodetect)",
     "nodejs_package_manager_path": "npm",

--- a/src/app/User/Application/ApplicationTest/RegisterUserUseCaseTest.php
+++ b/src/app/User/Application/ApplicationTest/RegisterUserUseCaseTest.php
@@ -2,7 +2,7 @@
 
 namespace App\User\Application\ApplicationTest;
 
-use App\User\Application\UseCase\RegisterUserUsecase;
+use App\User\Application\UseCase\RegisterUserUseCase;
 use App\User\Infrastructure\Repository\UserRepository;
 use App\User\Domain\Factory\UserEntityFactory;
 use App\User\Application\Dto\RegisterUserDto;
@@ -165,7 +165,7 @@ class RegisterUserUseCaseTest extends TestCase
      */
     public function test(): void
     {
-        $usecase = new RegisterUserUsecase(
+        $usecase = new RegisterUserUseCase(
             $this->mockRepository(),
             $this->mockPasswordHasher()
         );

--- a/src/app/User/Application/ApplicationTest/ShowUserDtoTest.php
+++ b/src/app/User/Application/ApplicationTest/ShowUserDtoTest.php
@@ -1,0 +1,116 @@
+<?php
+
+namespace App\User\Application\ApplicationTest;
+
+use App\Common\Domain\UserId;
+use App\User\Application\Dto\ShowUserDto;
+use App\User\Domain\Entity\UserEntity;
+use App\User\Domain\Factory\UserFromModelEntityFactory;
+use Tests\TestCase;
+use App\User\Domain\ValueObject\Email;
+use Mockery;
+
+class ShowUserDtoTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+    }
+
+    protected function tearDown(): void
+    {
+        parent::tearDown();
+    }
+
+    private function mockData(): array
+    {
+        return [
+            'id' => 1,
+            'first_name' => 'xabi',
+            'last_name' => 'alonso',
+            'bio' => 'I am a football player',
+            'email' => 'real-madrid14@test.com',
+            'location' => 'Spain',
+            'skills' => json_encode(['football', 'coaching']),
+            'profile_image' => 'https://example.com/image.jpg',
+        ];
+    }
+
+    private function mockEntity(): UserEntity
+    {
+        $factory = Mockery::mock(
+            'alias' . UserFromModelEntityFactory::class
+        );
+
+        $entity = Mockery::mock(UserEntity::class);
+
+        $factory
+            ->shouldReceive('buildFromModel')
+            ->andReturn($entity);
+
+        $entity
+            ->shouldReceive('getUserId')
+            ->andReturn(new UserId($this->mockData()['id']));
+
+        $entity
+            ->shouldReceive('getFirstName')
+            ->andReturn($this->mockData()['first_name']);
+
+        $entity
+            ->shouldReceive('getLastName')
+            ->andReturn($this->mockData()['last_name']);
+
+        $entity
+            ->shouldReceive('getBio')
+            ->andReturn($this->mockData()['bio']);
+
+        $entity
+            ->shouldReceive('getEmail')
+            ->andReturn(new Email($this->mockData()['email']));
+
+        $entity
+            ->shouldReceive('getLocation')
+            ->andReturn($this->mockData()['location']);
+
+        $entity
+            ->shouldReceive('getSkills')
+            ->andReturn(json_decode($this->mockData()['skills'], true));
+
+        $entity
+            ->shouldReceive('getProfileImage')
+            ->andReturn($this->mockData()['profile_image']);
+
+        return  $entity;
+    }
+
+    /**
+     * @test
+     * @testdox ShowUserDtoTest_build_successfully check type
+     */
+    public function test1(): void
+    {
+        $result = ShowUserDto::build(
+            $this->mockEntity()
+        );
+        $this->assertInstanceOf(ShowUserDto::class, $result);
+    }
+
+    /**
+     * @test
+     * @testdox ShowUserDtoTest_build_successfully check value
+     */
+    public function test2(): void
+    {
+        $result = ShowUserDto::build(
+            $this->mockEntity()
+        );
+
+        $this->assertEquals($result->id, new UserId($this->mockData()['id']));
+        $this->assertEquals($result->firstName, $this->mockData()['first_name']);
+        $this->assertEquals($result->lastName, $this->mockData()['last_name']);
+        $this->assertEquals($result->bio, $this->mockData()['bio']);
+        $this->assertEquals($result->location, $this->mockData()['location']);
+        $this->assertEquals($result->skills, json_decode($this->mockData()['skills'], true));
+        $this->assertEquals($result->profileImage, $this->mockData()['profile_image']);
+    }
+}

--- a/src/app/User/Application/ApplicationTest/ShowUserUseCaseTest.php
+++ b/src/app/User/Application/ApplicationTest/ShowUserUseCaseTest.php
@@ -1,0 +1,158 @@
+<?php
+
+namespace App\User\Application\ApplicationTest;
+
+use App\Models\User;
+use Tests\TestCase;
+use App\User\Application\UseCase\ShowUserUseCase;
+use App\User\Domain\Factory\UserFromModelEntityFactory;
+use App\User\Domain\RepositoryInterface\UserRepositoryInterface;
+use App\User\Domain\Entity\UserEntity;
+use App\User\Domain\ValueObject\Email;
+use App\User\Application\Dto\ShowUserDto;
+use Mockery;
+use App\Common\Domain\UserId;
+
+class ShowUserUseCaseTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+    }
+
+    protected function tearDown(): void
+    {
+        parent::tearDown();
+    }
+
+    private function mockUserEntity(): UserEntity
+    {
+        $factory = Mockery::mock(
+            'alias' . UserFromModelEntityFactory::class
+        );
+
+        $entity = Mockery::mock(UserEntity::class);
+
+        $factory
+            ->shouldReceive('build')
+            ->andReturn($entity);
+
+        $entity
+            ->shouldReceive('getUserId')
+            ->andReturn(new UserId($this->requestData()['id']));
+
+        $entity
+            ->shouldReceive('getFirstName')
+            ->andReturn($this->requestData()['first_name']);
+
+        $entity
+            ->shouldReceive('getLastName')
+            ->andReturn($this->requestData()['last_name']);
+
+        $entity
+            ->shouldReceive('getEmail')
+            ->andReturn(new Email($this->requestData()['email']));
+
+        $entity
+            ->shouldReceive('getBio')
+            ->andReturn($this->requestData()['bio']);
+
+        $entity
+            ->shouldReceive('getLocation')
+            ->andReturn($this->requestData()['location']);
+
+        $entity
+            ->shouldReceive('getSkills')
+            ->andReturn(json_decode($this->requestData()['skills'], true));
+
+        $entity
+            ->shouldReceive('getProfileImage')
+            ->andReturn($this->requestData()['profile_image']);
+
+        return $entity;
+    }
+
+    private function mockRepository()
+    {
+        $repository = Mockery::mock(UserRepositoryInterface::class);
+
+        $repository
+            ->shouldReceive('findById')
+            ->with(new Userid($this->requestData()['id']))
+            ->andReturn($this->mockUserEntity());
+
+        return $repository;
+    }
+
+    private function mockDto(): ShowUserDto
+    {
+        $dto = Mockery::mock(ShowUserDto::class);
+
+        $dto
+            ->shouldReceive('build')
+            ->with($this->mockUserEntity())
+            ->andReturn($dto);
+
+        return $dto;
+    }
+
+    private function requestData(): array
+    {
+        return [
+            'id' => 1,
+            'first_name' => 'Andres',
+            'last_name' => 'Iniesta',
+            'bio' => 'Soccer player',
+            'email' => 'barcelona8@test.com',
+            'location' => 'Spain',
+            'skills' => json_encode(['dribbling', 'passing']),
+            'profile_image' => 'https://example.com/profile.jpg',
+        ];
+    }
+
+    private function mockUser()
+    {
+        $user = Mockery::mock(User::class);
+
+        return $user;
+    }
+
+    /**
+     * @test
+     * @testdox ShowUserUseCaseTest_build_successfully check type
+     */
+    public function test1(): void
+    {
+        $useCase = new ShowUserUseCase(
+            $this->mockRepository(),
+        );
+
+        $result = $useCase->handle(
+            $this->requestData()['id']
+        );
+
+        $this->assertInstanceOf(ShowUserDto::class, $result);
+    }
+
+    /**
+     * @test
+     * @testdox ShowUserUseCaseTest_build_successfully check value
+     */
+    public function test2(): void
+    {
+        $useCase = new ShowUserUseCase(
+            $this->mockRepository(),
+        );
+
+        $result = $useCase->handle(
+            $this->requestData()['id']
+        );
+
+        foreach ($this->requestData() as $key => $expectedValue) {
+            $camelKey = lcfirst(str_replace('_', '', ucwords($key, '_')));
+            $getter = 'get' . ucfirst($camelKey);
+
+            $this->assertEquals($expectedValue, $result->$getter());
+        }
+    }
+}

--- a/src/app/User/Application/Dto/ShowUserDto.php
+++ b/src/app/User/Application/Dto/ShowUserDto.php
@@ -1,0 +1,78 @@
+<?php
+
+namespace App\User\Application\Dto;
+
+use App\Common\Domain\UserId;
+use App\User\Domain\Entity\UserEntity;
+use App\User\Domain\ValueObject\Email;
+
+class ShowUserDto
+{
+    public function __construct(
+        public readonly UserId $id,
+        public readonly string $firstName,
+        public readonly string $lastName,
+        public readonly Email $email,
+        public readonly ?string $bio,
+        public readonly ?string $location,
+        public readonly array $skills,
+        public readonly ?string $profileImage
+    ) {
+    }
+
+    public function getId(): UserId
+    {
+        return $this->id;
+    }
+
+    public function getFirstName(): string
+    {
+        return $this->firstName;
+    }
+
+    public function getLastName(): string
+    {
+        return $this->lastName;
+    }
+
+    public function getEmail(): Email
+    {
+        return $this->email;
+    }
+
+    public function getBio(): ?string
+    {
+        return $this->bio ?? null;
+    }
+
+    public function getLocation(): ?string
+    {
+        return $this->location ?? null;
+    }
+
+    public function getSkills(): array
+    {
+        return $this->skills;
+    }
+
+    public function getProfileImage(): ?string
+    {
+        return $this->profileImage ?? null;
+    }
+
+    public static function build(
+        UserEntity $entity
+    ): self
+    {
+        return new self(
+            id: new UserId($entity->getUserId()->getValue()),
+            firstName: $entity->getFirstName(),
+            lastName: $entity->getLastName(),
+            email: $entity->getEmail(),
+            bio: $entity->getBio(),
+            location: $entity->getLocation(),
+            skills: $entity->getSkills(),
+            profileImage: $entity->getProfileImage()
+        );
+    }
+}

--- a/src/app/User/Application/UseCase/RegisterUserUseCase.php
+++ b/src/app/User/Application/UseCase/RegisterUserUseCase.php
@@ -9,7 +9,7 @@ use App\User\Domain\RepositoryInterface\UserRepositoryInterface;
 use App\User\Domain\Factory\UserEntityFactory;
 use App\User\Application\Factory\RegisterUserDtoFactory;
 
-class RegisterUserUsecase
+class RegisterUserUseCase
 {
     public function __construct(
         readonly private UserRepositoryInterface $repository,

--- a/src/app/User/Application/UseCase/ShowUserUseCase.php
+++ b/src/app/User/Application/UseCase/ShowUserUseCase.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace App\User\Application\UseCase;
+
+use App\Common\Domain\UserId;
+use App\Models\User;
+use App\User\Domain\RepositoryInterface\UserRepositoryInterface;
+use App\User\Application\Dto\ShowUserDto;
+use App\User\Domain\Factory\UserFromModelEntityFactory;
+use Exception;
+
+class ShowUserUseCase
+{
+    public function __construct(
+        readonly private UserRepositoryInterface $repository,
+    ) {
+    }
+
+    public function handle(
+        int $userId
+    ): ShowUserDto
+    {
+        $userEntity = $this->repository->findById(new UserId($userId));
+
+        return ShowUserDto::build($userEntity);
+    }
+}

--- a/src/app/User/Presentation/Controller/UserController.php
+++ b/src/app/User/Presentation/Controller/UserController.php
@@ -7,7 +7,7 @@ use App\User\Application\Factory\RegisterUserCommandFactory;
 use App\User\Presentation\ViewModel\Factory\RegisterUserViewModelFactory;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
-use App\User\Application\UseCase\RegisterUserUsecase;
+use App\User\Application\UseCase\RegisterUserUseCase;
 use Illuminate\Support\Facades\DB;
 use Exception;
 
@@ -15,7 +15,7 @@ class UserController extends Controller
 {
     public function createUser(
         Request $request,
-        RegisterUserUsecase $useCase
+        RegisterUserUseCase $useCase
     ): JsonResponse
     {
         DB::connection('mysql')->beginTransaction();

--- a/src/app/User/Presentation/PresentationTest/Controller/UserController_registerTest.php
+++ b/src/app/User/Presentation/PresentationTest/Controller/UserController_registerTest.php
@@ -3,7 +3,7 @@
 namespace App\User\Presentation\PresentationTest\Controller;
 
 use App\Common\Domain\UserId;
-use App\User\Application\UseCase\RegisterUserUsecase;
+use App\User\Application\UseCase\RegisterUserUseCase;
 use App\User\Application\UseCommand\RegisterUserCommand;
 use App\User\Presentation\Controller\UserController;
 use App\User\Application\Dto\RegisterUserDto;
@@ -101,9 +101,9 @@ class UserController_registerTest extends TestCase
         return $command;
     }
 
-    private function mockUseCase(): RegisterUserUsecase
+    private function mockUseCase(): RegisterUserUseCase
     {
-        $useCase = Mockery::mock(RegisterUserUsecase::class);
+        $useCase = Mockery::mock(RegisterUserUseCase::class);
 
         $useCase
             ->shouldReceive('handle')


### PR DESCRIPTION
### Overview

This pull request introduces the `ShowUserUseCase`, a dedicated application-layer class responsible for retrieving a user profile by user ID.

### Details

- Accepts a raw integer user ID and wraps it in a domain-specific `UserId` value object.
- Delegates user retrieval to the `UserRepositoryInterface` abstraction.
- Returns a `ShowUserDto`, constructed via the `ShowUserDto::build()` method.

### Rationale

This use case separates application logic from both presentation and domain implementation details.  
By using a value object (`UserId`) and a DTO (`ShowUserDto`), the class maintains clarity and supports future extensions without polluting domain or infrastructure layers.
