### PR TITLE
Apply ViewModel transformation and structured JSON response in user profile controller

### DIFF
--- a/.idea/workspace.xml
+++ b/.idea/workspace.xml
@@ -5,11 +5,9 @@
   </component>
   <component name="ChangeListManager">
     <list default="true" id="6952a861-17ec-40ad-b866-c564752c14a8" name="変更" comment="fix: test-environment-fix">
-      <change afterPath="$PROJECT_DIR$/src/app/User/Application/ApplicationTest/ShowUserDtoTest.php" afterDir="false" />
-      <change afterPath="$PROJECT_DIR$/src/app/User/Application/Dto/ShowUserDto.php" afterDir="false" />
-      <change afterPath="$PROJECT_DIR$/src/app/User/Presentation/PresentationTest/ShowUserViewModelTest.php" afterDir="false" />
-      <change afterPath="$PROJECT_DIR$/src/app/User/Presentation/ViewModel/ShowUserViewModel.php" afterDir="false" />
+      <change afterPath="$PROJECT_DIR$/src/app/User/Presentation/PresentationTest/Controller/UserController_showTest.php" afterDir="false" />
       <change beforePath="$PROJECT_DIR$/.idea/workspace.xml" beforeDir="false" afterPath="$PROJECT_DIR$/.idea/workspace.xml" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/app/User/Presentation/Controller/UserController.php" beforeDir="false" afterPath="$PROJECT_DIR$/src/app/User/Presentation/Controller/UserController.php" afterDir="false" />
     </list>
     <option name="SHOW_DIALOG" value="false" />
     <option name="HIGHLIGHT_CONFLICTS" value="true" />
@@ -164,7 +162,7 @@
     "PHPUnit.メイン.executor": "Run",
     "RunOnceActivity.ShowReadmeOnStart": "true",
     "RunOnceActivity.git.unshallow": "true",
-    "git-widget-placeholder": "feature/show-user-presentation-viewmodel",
+    "git-widget-placeholder": "feature/show-user-controller",
     "node.js.detected.package.eslint": "true",
     "node.js.selected.package.eslint": "(autodetect)",
     "nodejs_package_manager_path": "npm",

--- a/src/app/User/Presentation/Controller/UserController.php
+++ b/src/app/User/Presentation/Controller/UserController.php
@@ -4,7 +4,9 @@ namespace App\User\Presentation\Controller;
 
 use App\Http\Controllers\Controller;
 use App\User\Application\Factory\RegisterUserCommandFactory;
+use App\User\Application\UseCase\ShowUserUseCase;
 use App\User\Presentation\ViewModel\Factory\RegisterUserViewModelFactory;
+use App\User\Presentation\ViewModel\ShowUserViewModel;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
 use App\User\Application\UseCase\RegisterUserUsecase;
@@ -39,5 +41,19 @@ class UserController extends Controller
                 'message' => $e->getMessage(),
             ], 500);
         }
+    }
+
+    public function showUser(
+        int $id,
+        ShowUserUseCase $useCase
+    ): JsonResponse
+    {
+        $dto = $useCase->handle($id);
+        $viewModel = ShowUserViewModel::buildFromDto($dto);
+
+        return response()->json([
+            'status' => 'success',
+            'data' => $viewModel->toArray(),
+        ], 200);
     }
 }

--- a/src/app/User/Presentation/PresentationTest/Controller/UserController_showTest.php
+++ b/src/app/User/Presentation/PresentationTest/Controller/UserController_showTest.php
@@ -1,0 +1,145 @@
+<?php
+
+namespace App\User\Presentation\PresentationTest\Controller;
+
+use App\User\Application\Dto\ShowUserDto;
+use App\User\Application\UseCase\ShowUserUseCase;
+use App\User\Presentation\Controller\UserController;
+use App\User\Presentation\ViewModel\ShowUserViewModel;
+use Illuminate\Http\JsonResponse;
+use Tests\TestCase;
+use Mockery;
+use App\Common\Domain\UserId;
+use App\User\Domain\ValueObject\Email;
+
+class UserController_showTest extends TestCase
+{
+    private UserController $controller;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->controller = new UserController();
+    }
+
+    protected function tearDown(): void
+    {
+        parent::tearDown();
+    }
+
+    private function mockUseCase(): ShowUserUseCase
+    {
+        $useCase = Mockery::mock(ShowUserUseCase::class);
+
+        $useCase
+            ->shouldReceive('handle')
+            ->andReturn($this->mockDto());
+
+        return $useCase;
+    }
+
+    private function mockDto(): ShowUserDto
+    {
+        $dto = Mockery::mock(ShowUserDto::class);
+
+        $dto
+            ->shouldReceive('getId')
+            ->andReturn(new UserId($this->arrayTestData()['id']));
+
+        $dto
+            ->shouldReceive('getFirstName')
+            ->andReturn($this->arrayTestData()['first_name']);
+
+        $dto
+            ->shouldReceive('getLastName')
+            ->andReturn($this->arrayTestData()['last_name']);
+
+        $dto
+            ->shouldReceive('getEmail')
+            ->andReturn(new Email($this->arrayTestData()['email']));
+
+        $dto
+            ->shouldReceive('getBio')
+            ->andReturn($this->arrayTestData()['bio']);
+
+        $dto
+            ->shouldReceive('getLocation')
+            ->andReturn($this->arrayTestData()['location']);
+
+        $dto
+            ->shouldReceive('getSkills')
+            ->andReturn($this->arrayTestData()['skills']);
+
+        $dto
+            ->shouldReceive('getProfileImage')
+            ->andReturn($this->arrayTestData()['profile_image']);
+
+        return $dto;
+    }
+
+    private function mockViewModel(): ShowUserViewModel
+    {
+        $viewModel = Mockery::mock(ShowUserViewModel::class);
+
+        $viewModel
+            ->shouldReceive('toArray')
+            ->andReturn($this->arrayTestData());
+
+        return $viewModel;
+    }
+
+    private function arrayTestData(): array
+    {
+        return [
+            'id' => 1,
+            'first_name' => 'Frank',
+            'last_name' => 'Lampard',
+            'bio' => 'A former footballer and current manager',
+            'location' => 'London',
+            'email' => 'chelsea8@test.com',
+            'skills' => ['coaching', 'leadership'],
+            'profile_image' => 'https://example.com/profile.jpg'
+        ];
+    }
+
+    /**
+     * @test
+     * @testdox UserController_show_successfully
+     */
+    public function test1(): void
+    {
+        $useCase = $this->mockUseCase();
+
+        $result = $this->controller
+            ->showUser(
+                $this->arrayTestData()['id'],
+                $useCase,
+            );
+
+        $this->assertInstanceOf(JsonResponse::class, $result);
+    }
+
+    /**
+     * @test
+     * @testdox UserController_show_successfully check value
+     */
+    public function test2(): void
+    {
+        $useCase = $this->mockUseCase();
+
+        $result = $this->controller
+            ->showUser(
+                $this->arrayTestData()['id'],
+                $useCase,
+            );
+        $fullName = $this->arrayTestData()['first_name'] . ' ' . $this->arrayTestData()['last_name'];
+
+        $this->assertEquals($this->arrayTestData()['id'], $result->getOriginalContent()['data']['id']);
+        $this->assertEquals($fullName, $result->getOriginalContent()['data']['full_name']);
+        $this->assertEquals($this->arrayTestData()['bio'], $result->getOriginalContent()['data']['bio']);
+        $this->assertEquals($this->arrayTestData()['location'], $result->getOriginalContent()['data']['location']);
+        $this->assertEquals($this->arrayTestData()['email'], $result->getOriginalContent()['data']['email']);
+        $this->assertEquals($this->arrayTestData()['skills'], json_decode($result->getOriginalContent()['data']['skills'], true));
+        $this->assertEquals($this->arrayTestData()['profile_image'], $result->getOriginalContent()['data']['profile_image']);
+    }
+}


### PR DESCRIPTION
### Overview

This pull request updates the user profile controller to apply a structured presentation layer using `ShowUserViewModel`.  
The response is now returned in a consistent JSON structure suitable for frontend consumption.

### Details

- Injects `ShowUserUseCase` and retrieves the corresponding `ShowUserDto` for a given user ID.
- Transforms the DTO into a `ShowUserViewModel` using `buildFromDto()`.
- Returns a structured JSON response with `status` and `data` keys.
- Ensures a clean separation between application logic (DTO) and presentation formatting (ViewModel).

### Rationale

Returning raw DTOs in API responses can expose internal structures or lack formatting control.  
This update introduces a dedicated ViewModel layer to produce consistent, frontend-ready responses while preserving application-layer boundaries.