### PR TITLE
Implement `UserRepository::update()` logic in infrastructure layer

### DIFF
--- a/.idea/workspace.xml
+++ b/.idea/workspace.xml
@@ -5,7 +5,12 @@
   </component>
   <component name="ChangeListManager">
     <list default="true" id="6952a861-17ec-40ad-b866-c564752c14a8" name="変更" comment="fix: test-environment-fix">
+      <change afterPath="$PROJECT_DIR$/src/app/User/Infrastructure/InfrastructureTest/UserRepository_updateTest.php" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/.idea/workspace.xml" beforeDir="false" afterPath="$PROJECT_DIR$/.idea/workspace.xml" afterDir="false" />
       <change beforePath="$PROJECT_DIR$/src/app/User/Domain/DomainTest/UserUpdateEntityFactoryTest.php" beforeDir="false" afterPath="$PROJECT_DIR$/src/app/User/Domain/DomainTest/UserUpdateEntityFactoryTest.php" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/app/User/Domain/Factory/UserUpdateEntityFactory.php" beforeDir="false" afterPath="$PROJECT_DIR$/src/app/User/Domain/Factory/UserUpdateEntityFactory.php" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/app/User/Domain/RepositoryInterface/UserRepositoryInterface.php" beforeDir="false" afterPath="$PROJECT_DIR$/src/app/User/Domain/RepositoryInterface/UserRepositoryInterface.php" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/app/User/Infrastructure/Repository/UserRepository.php" beforeDir="false" afterPath="$PROJECT_DIR$/src/app/User/Infrastructure/Repository/UserRepository.php" afterDir="false" />
     </list>
     <option name="SHOW_DIALOG" value="false" />
     <option name="HIGHLIGHT_CONFLICTS" value="true" />
@@ -160,7 +165,7 @@
     "PHPUnit.メイン.executor": "Run",
     "RunOnceActivity.ShowReadmeOnStart": "true",
     "RunOnceActivity.git.unshallow": "true",
-    "git-widget-placeholder": "feature/domain-entity-factory",
+    "git-widget-placeholder": "feature/edit-user-repository-infra",
     "node.js.detected.package.eslint": "true",
     "node.js.selected.package.eslint": "(autodetect)",
     "nodejs_package_manager_path": "npm",

--- a/src/app/User/Domain/DomainTest/UserUpdateEntityFactoryTest.php
+++ b/src/app/User/Domain/DomainTest/UserUpdateEntityFactoryTest.php
@@ -2,7 +2,7 @@
 
 namespace App\User\Domain\DomainTest;
 
-use App\Models\User;
+use Mockery;
 use Tests\TestCase;
 use App\User\Domain\Entity\UserEntity;
 use App\Common\Domain\UserId;
@@ -36,13 +36,52 @@ class UserUpdateEntityFactoryTest extends TestCase
         ];
     }
 
+    private function mockEntity(): UserEntity
+    {
+        $entity = Mockery::mock(UserEntity::class);
+
+        $entity
+            ->shouldReceive('getUserId')
+            ->andReturn(new UserId($this->arrayRequestData()['id']));
+
+        $entity
+            ->shouldReceive('getFirstName')
+            ->andReturn($this->arrayRequestData()['first_name']);
+
+        $entity
+            ->shouldReceive('getLastName')
+            ->andReturn($this->arrayRequestData()['last_name']);
+
+        $entity
+            ->shouldReceive('getEmail')
+            ->andReturn(new Email($this->arrayRequestData()['email']));
+
+        $entity
+            ->shouldReceive('getBio')
+            ->andReturn($this->arrayRequestData()['bio']);
+
+        $entity
+            ->shouldReceive('getLocation')
+            ->andReturn($this->arrayRequestData()['location']);
+
+        $entity
+            ->shouldReceive('getSkills')
+            ->andReturn($this->arrayRequestData()['skills']);
+
+        $entity
+            ->shouldReceive('getProfileImage')
+            ->andReturn($this->arrayRequestData()['profile_image']);
+
+        return $entity;
+    }
+
     /**
      * @test
      * @testdox UserUpdateEntityFactory_build_successfully check type
      */
     public function test1(): void
     {
-        $result = UserUpdateEntityFactory::build($this->arrayRequestData());
+        $result = UserUpdateEntityFactory::build($this->mockEntity());
 
         $this->assertInstanceOf(UserEntity::class, $result);
     }
@@ -53,7 +92,7 @@ class UserUpdateEntityFactoryTest extends TestCase
      */
     public function test2(): void
     {
-        $result = UserUpdateEntityFactory::build($this->arrayRequestData());
+        $result = UserUpdateEntityFactory::build($this->mockEntity());
 
         $this->assertEquals($result->getFirstName(), $this->arrayRequestData()['first_name']);
         $this->assertEquals($result->getLastName(), $this->arrayRequestData()['last_name']);
@@ -81,7 +120,41 @@ class UserUpdateEntityFactoryTest extends TestCase
             'profile_image' => 'https://example.com/profile.jpg',
         ];
 
-        $result = UserUpdateEntityFactory::build($partiallyData);
+        $partiallyEntity = Mockery::mock(UserEntity::class);
+
+        $partiallyEntity
+            ->shouldReceive('getUserId')
+            ->andReturn(new UserId($partiallyData['id']));
+
+        $partiallyEntity
+            ->shouldReceive('getFirstName')
+            ->andReturn($partiallyData['first_name']);
+
+        $partiallyEntity
+            ->shouldReceive('getLastName')
+            ->andReturn($partiallyData['last_name']);
+
+        $partiallyEntity
+            ->shouldReceive('getEmail')
+            ->andReturn(new Email($partiallyData['email']));
+
+        $partiallyEntity
+            ->shouldReceive('getBio')
+            ->andReturn(null);
+
+        $partiallyEntity
+            ->shouldReceive('getLocation')
+            ->andReturn($partiallyData['location']);
+
+        $partiallyEntity
+            ->shouldReceive('getSkills')
+            ->andReturn($partiallyData['skills']);
+
+        $partiallyEntity
+            ->shouldReceive('getProfileImage')
+            ->andReturn($partiallyData['profile_image']);
+
+        $result = UserUpdateEntityFactory::build($partiallyEntity);
 
         $this->assertEquals($result->getFirstName(), $partiallyData['first_name']);
         $this->assertEquals($result->getLastName(), $partiallyData['last_name']);

--- a/src/app/User/Domain/Factory/UserUpdateEntityFactory.php
+++ b/src/app/User/Domain/Factory/UserUpdateEntityFactory.php
@@ -8,19 +8,17 @@ use App\User\Domain\ValueObject\Email;
 
 class UserUpdateEntityFactory
 {
-    public static function build(array $request): UserEntity
+    public static function build(UserEntity $entity): UserEntity
     {
         return new UserEntity(
-            id: new Userid($request['id']),
-            firstName: $request['first_name'],
-            lastName: $request['last_name'],
-            email: new Email($request['email']),
-            bio: $request['bio'] ?? null,
-            location: $request['location'] ?? null,
-            skills: is_string($request['skills'])
-                ? json_decode($request['skills'], true)
-                : (is_array($request['skills']) ? $request['skills'] : []),
-            profileImage: $request['profile_image'] ?? null
+            id: new Userid($entity->getUserId()?->getValue()),
+            firstName: $entity->getFirstName(),
+            lastName: $entity->getLastName(),
+            email: new Email($entity->getEmail()->getValue()),
+            bio: $entity->getBio() ?? null,
+            location: $entity->getLocation() ?? null,
+            skills: $entity->getSkills() ?? [],
+            profileImage: $entity->getProfileImage() ?? null,
         );
     }
 }

--- a/src/app/User/Domain/RepositoryInterface/UserRepositoryInterface.php
+++ b/src/app/User/Domain/RepositoryInterface/UserRepositoryInterface.php
@@ -13,4 +13,6 @@ interface UserRepositoryInterface
     public function existsByEmail(Email $email): bool;
 
     public function findById(UserId $id): UserEntity;
+
+    public function update(UserEntity $entity): UserEntity;
 }

--- a/src/app/User/Infrastructure/InfrastructureTest/UserRepository_updateTest.php
+++ b/src/app/User/Infrastructure/InfrastructureTest/UserRepository_updateTest.php
@@ -1,0 +1,162 @@
+<?php
+
+namespace App\User\Infrastructure\InfrastructureTest;
+
+use App\User\Domain\RepositoryInterface\PasswordHasherInterface;
+use App\User\Infrastructure\Repository\UserRepository;
+use Tests\TestCase;
+use Mockery;
+use App\User\Domain\Entity\UserEntity;
+use App\User\Domain\ValueObject\Email;
+use App\Common\Domain\UserId;
+use App\User\Domain\Factory\UserUpdateEntityFactory;
+use Illuminate\Support\Facades\DB;
+use App\Models\User;
+
+class UserRepository_updateTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->refresh();
+        $this->user = $this->initialInsert();
+        $this->repository = new UserRepository(
+            $this->mockHasher()
+        );
+    }
+
+    protected function tearDown(): void
+    {
+        parent::tearDown();
+        $this->refresh();
+    }
+
+    private function refresh(): void
+    {
+        if (env('APP_ENV') === 'testing') {
+            DB::connection('mysql')->statement('SET FOREIGN_KEY_CHECKS=0;');
+            User::truncate();
+            DB::connection('mysql')->statement('SET FOREIGN_KEY_CHECKS=1;');
+        }
+    }
+
+    private function mockHasher(): PasswordHasherInterface
+    {
+        $hasher = Mockery::mock(PasswordHasherInterface::class);
+
+        $hasher->shouldReceive('hash')
+            ->with($this->user->password)
+            ->andReturn($this->user->password);
+
+        return $hasher;
+    }
+
+    private function initialInsert(): User
+    {
+        $user = User::create([
+            'first_name' => 'Toni',
+            'last_name' => 'Kroos',
+            'email' => 'real-madrid6@test.com',
+            'password' => 'el-capitán-1234',
+            'bio' => 'Real Madrid player',
+            'location' => 'Madrid',
+            'skills' => ['Football', 'Leadership'],
+            'profile_image' => 'https://example.com/sergio.jpg'
+        ]);
+
+        return $user;
+    }
+
+    private function updateData(): array
+    {
+        return [
+            'id' => $this->user->id,
+            'first_name' => 'Sergio',
+            'last_name' => 'Aguero',
+            'email' => 'man-city10@test.com',
+            'bio' => null,
+            'location' => null,
+            'skills' => ['Football', 'Leadership', 'Laravel'],
+            'profile_image' => 'https://example.com/sergio.jpg'
+        ];
+    }
+
+    private function mockEntity(): UserEntity
+    {
+        $factory = Mockery::mock(
+            'alias' . UserUpdateEntityFactory::class
+        );
+
+        $entity = Mockery::mock(UserEntity::class);
+
+        $factory
+            ->shouldReceive('build')
+            ->andReturn($entity);
+
+        $entity
+            ->shouldReceive('getUserId')
+            ->andReturn(new UserId($this->user->id));
+
+        $entity
+            ->shouldReceive('getFirstName')
+            ->andReturn($this->updateData()['first_name']);
+
+        $entity
+            ->shouldReceive('getLastName')
+            ->andReturn($this->updateData()['last_name']);
+
+        $entity
+            ->shouldReceive('getEmail')
+            ->andReturn(new Email($this->updateData()['email']));
+
+        $entity
+            ->shouldReceive('getBio')
+            ->andReturn($this->updateData()['bio']);
+
+        $entity
+            ->shouldReceive('getLocation')
+            ->andReturn($this->updateData()['location']);
+
+        $entity
+            ->shouldReceive('getSkills')
+            ->andReturn($this->updateData()['skills']);
+
+        $entity
+            ->shouldReceive('getProfileImage')
+            ->andReturn($this->updateData()['profile_image']);
+
+        return $entity;
+    }
+
+    /**
+     * @test
+     * @testdox UserRepository_update_successfully
+     */
+    public function test1(): void
+    {
+        $result = $this->repository->update(
+            $this->mockEntity()
+        );
+
+        $this->assertInstanceOf(UserEntity::class, $result);
+    }
+
+    /**
+     * @test
+     * @testdox UserRepository_update_successfully check value
+     */
+    public function test2(): void
+    {
+        $result = $this->repository->update(
+            $this->mockEntity()
+        );
+
+        $this->assertEquals($result->getFirstName(), $this->updateData()['first_name']);
+        $this->assertEquals($result->getLastName(), $this->updateData()['last_name']);
+        $this->assertEquals($result->getEmail()->getValue(), $this->updateData()['email']);
+        $this->assertEquals($result->getBio(), $this->updateData()['bio']);
+        $this->assertEquals($result->getLocation(), $this->updateData()['location']);
+        $this->assertEquals($result->getSkills(), $this->updateData()['skills']);
+        $this->assertEquals($result->getProfileImage(), $this->updateData()['profile_image']);
+    }
+}

--- a/src/app/User/Infrastructure/Repository/UserRepository.php
+++ b/src/app/User/Infrastructure/Repository/UserRepository.php
@@ -6,6 +6,7 @@ use App\Common\Domain\UserId;
 use App\Models\User;
 use App\User\Domain\Entity\UserEntity;
 use App\User\Domain\Factory\UserFromModelEntityFactory;
+use App\User\Domain\Factory\UserUpdateEntityFactory;
 use App\User\Domain\RepositoryInterface\UserRepositoryInterface;
 use App\User\Domain\ValueObject\Email;
 use App\User\Domain\RepositoryInterface\PasswordHasherInterface;
@@ -52,5 +53,18 @@ class UserRepository implements UserRepositoryInterface
         }
 
         return UserFromModelEntityFactory::buildFromModel($findUser);
+    }
+
+    public function update(
+        UserEntity $entity
+    ): UserEntity
+    {
+        $targetUser = User::find($entity->getUserId()->getValue());
+
+        if ($targetUser === null) {
+            throw new Exception('User not found');
+        }
+
+        return UserUpdateEntityFactory::build($entity);
     }
 }


### PR DESCRIPTION
### Overview

This pull request adds the infrastructure-level implementation of the `update()` method to the `UserRepository` class.  
The method is responsible for retrieving the target user by ID and returning a domain entity constructed through `UserUpdateEntityFactory`.

### Changes

- Implemented `UserRepository::update(UserEntity $entity): UserEntity`
- Retrieves the user model using `User::find(...)`
- Throws a domain-level exception if the user is not found
- Returns a `UserEntity` reconstructed via `UserUpdateEntityFactory::build(...)`

### Rationale

This update provides the infrastructure support required by the update user profile use case.  
It separates persistence logic from domain behaviour and keeps the interface aligned with DDD principles.  
By returning a `UserEntity`, the application layer can operate in a domain-centric manner without being tightly coupled to Eloquent models.