### PR TITLE
Add `UpdateUserCommand` to encapsulate user profile update request data

### DIFF
--- a/.idea/workspace.xml
+++ b/.idea/workspace.xml
@@ -5,9 +5,6 @@
   </component>
   <component name="ChangeListManager">
     <list default="true" id="6952a861-17ec-40ad-b866-c564752c14a8" name="変更" comment="fix: test-environment-fix">
-      <change afterPath="$PROJECT_DIR$/src/app/User/Application/ApplicationTest/UpdateUserCommandTest.php" afterDir="false" />
-      <change afterPath="$PROJECT_DIR$/src/app/User/Application/Factory/UpdateUserCommandFactory.php" afterDir="false" />
-      <change afterPath="$PROJECT_DIR$/src/app/User/Application/UseCommand/UpdateUserCommand.php" afterDir="false" />
       <change beforePath="$PROJECT_DIR$/.idea/workspace.xml" beforeDir="false" afterPath="$PROJECT_DIR$/.idea/workspace.xml" afterDir="false" />
     </list>
     <option name="SHOW_DIALOG" value="false" />

--- a/.idea/workspace.xml
+++ b/.idea/workspace.xml
@@ -5,12 +5,10 @@
   </component>
   <component name="ChangeListManager">
     <list default="true" id="6952a861-17ec-40ad-b866-c564752c14a8" name="変更" comment="fix: test-environment-fix">
-      <change afterPath="$PROJECT_DIR$/src/app/User/Infrastructure/InfrastructureTest/UserRepository_updateTest.php" afterDir="false" />
+      <change afterPath="$PROJECT_DIR$/src/app/User/Application/ApplicationTest/UpdateUserCommandTest.php" afterDir="false" />
+      <change afterPath="$PROJECT_DIR$/src/app/User/Application/Factory/UpdateUserCommandFactory.php" afterDir="false" />
+      <change afterPath="$PROJECT_DIR$/src/app/User/Application/UseCommand/UpdateUserCommand.php" afterDir="false" />
       <change beforePath="$PROJECT_DIR$/.idea/workspace.xml" beforeDir="false" afterPath="$PROJECT_DIR$/.idea/workspace.xml" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/src/app/User/Domain/DomainTest/UserUpdateEntityFactoryTest.php" beforeDir="false" afterPath="$PROJECT_DIR$/src/app/User/Domain/DomainTest/UserUpdateEntityFactoryTest.php" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/src/app/User/Domain/Factory/UserUpdateEntityFactory.php" beforeDir="false" afterPath="$PROJECT_DIR$/src/app/User/Domain/Factory/UserUpdateEntityFactory.php" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/src/app/User/Domain/RepositoryInterface/UserRepositoryInterface.php" beforeDir="false" afterPath="$PROJECT_DIR$/src/app/User/Domain/RepositoryInterface/UserRepositoryInterface.php" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/src/app/User/Infrastructure/Repository/UserRepository.php" beforeDir="false" afterPath="$PROJECT_DIR$/src/app/User/Infrastructure/Repository/UserRepository.php" afterDir="false" />
     </list>
     <option name="SHOW_DIALOG" value="false" />
     <option name="HIGHLIGHT_CONFLICTS" value="true" />
@@ -165,7 +163,7 @@
     "PHPUnit.メイン.executor": "Run",
     "RunOnceActivity.ShowReadmeOnStart": "true",
     "RunOnceActivity.git.unshallow": "true",
-    "git-widget-placeholder": "feature/edit-user-repository-infra",
+    "git-widget-placeholder": "feature/edit-user-command",
     "node.js.detected.package.eslint": "true",
     "node.js.selected.package.eslint": "(autodetect)",
     "nodejs_package_manager_path": "npm",

--- a/src/app/User/Application/ApplicationTest/UpdateUserCommandTest.php
+++ b/src/app/User/Application/ApplicationTest/UpdateUserCommandTest.php
@@ -1,0 +1,72 @@
+<?php
+
+namespace App\User\Application\ApplicationTest;
+
+use App\User\Application\UseCommand\UpdateUserCommand;
+use Illuminate\Http\Request;
+use Tests\TestCase;
+use Mockery;
+
+class UpdateUserCommandTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+    }
+
+    protected function tearDown(): void
+    {
+        parent::tearDown();
+    }
+
+    /**
+     * @test
+     * @testdox RegisterUserCommandFactoryTest_build_successfully check type
+     */
+    public function test1(): void
+    {
+        $result = UpdateUserCommand::build($this->mockRequest());
+
+        $this->assertInstanceOf(UpdateUserCommand::class, $result);
+    }
+
+    /**
+     * @test
+     * @testdox RegisterUserCommandFactoryTest_build_successfully check value
+     */
+    public function test2(): void
+    {
+        $result = UpdateUserCommand::build($this->mockRequest());
+        foreach ($this->arrayRequestData() as $key => $expectedValue) {
+            $camelKey = lcfirst(str_replace('_', '', ucwords($key, '_')));
+            $getter = 'get' . ucfirst($camelKey);
+
+            $this->assertEquals($expectedValue, $result->$getter());
+        }
+    }
+
+    private function mockRequest(): Request
+    {
+        $mockRequest = Mockery::mock(Request::class);
+
+        $mockRequest
+            ->shouldReceive('toArray')
+            ->andReturn($this->arrayRequestData());
+
+        return $mockRequest;
+    }
+
+    private function arrayRequestData(): array
+    {
+        return [
+            'id' => 1,
+            'first_name' => 'Cristiano',
+            'last_name' => 'Ronaldo',
+            'bio' => 'I am a football player',
+            'email' => 'manchester-united7@test.com',
+            'location' => 'Manchester',
+            'skills' => ['Laravel', 'React'],
+            'profile_image' => 'https://example.com/profile.jpg',
+        ];
+    }
+}

--- a/src/app/User/Application/UseCommand/UpdateUserCommand.php
+++ b/src/app/User/Application/UseCommand/UpdateUserCommand.php
@@ -44,12 +44,12 @@ class UpdateUserCommand
 
     public function getBio(): ?string
     {
-        return $this->bio ?? null;
+        return $this->bio;
     }
 
     public function getLocation(): ?string
     {
-        return $this->location ?? null;
+        return $this->location;
     }
 
     public function getSkills(): array

--- a/src/app/User/Application/UseCommand/UpdateUserCommand.php
+++ b/src/app/User/Application/UseCommand/UpdateUserCommand.php
@@ -1,0 +1,106 @@
+<?php
+
+namespace App\User\Application\UseCommand;
+
+use App\Common\Domain\UserId;
+use Illuminate\Http\Request;
+use InvalidArgumentException;
+
+
+
+class UpdateUserCommand
+{
+    public function __construct(
+        public readonly int $id,
+        public readonly string $firstName,
+        public readonly string $lastName,
+        public readonly string $email,
+        public readonly ?string $bio,
+        public readonly ?string $location,
+        public readonly array $skills,
+        public readonly ?string $profileImage
+    ) {
+    }
+
+    public function getId(): int
+    {
+        return $this->id;
+    }
+
+    public function getFirstName(): string
+    {
+        return $this->firstName;
+    }
+
+    public function getLastName(): string
+    {
+        return $this->lastName;
+    }
+
+    public function getEmail(): string
+    {
+        return $this->email;
+    }
+
+    public function getBio(): ?string
+    {
+        return $this->bio ?? null;
+    }
+
+    public function getLocation(): ?string
+    {
+        return $this->location ?? null;
+    }
+
+    public function getSkills(): array
+    {
+        return $this->skills;
+    }
+
+    public function getProfileImage(): ?string
+    {
+        return $this->profileImage ?? null;
+    }
+
+    public static function build(
+        Request $request
+    ): self
+    {
+        $requestArray = $request->toArray();
+        self::validation($requestArray);
+
+        return new self(
+            $requestArray['id'],
+            $requestArray['first_name'],
+            $requestArray['last_name'],
+            $requestArray['email'],
+            $requestArray['bio'] ?? null,
+            $requestArray['location'] ?? null,
+            $requestArray['skills'] ?? [],
+            $requestArray['profile_image'] ?? null
+        );
+    }
+
+    private static function validation(
+        array $request
+    ): bool
+    {
+        foreach (self::PROPERTIES as $property) {
+            if (!array_key_exists($property, $request)) {
+                throw new InvalidArgumentException("Missing required property: {$property}");
+            }
+        }
+        return true;
+    }
+
+    private const PROPERTIES = [
+        'id',
+        'first_name',
+        'last_name',
+        'email',
+        'bio',
+        'location',
+        'skills',
+        'profile_image'
+    ];
+}


### PR DESCRIPTION
### Overview

This pull request introduces the `UpdateUserCommand` class to the Application layer.  
It encapsulates incoming request data for updating a user's profile and provides value-level validation before creating the command instance.

### Details

- Defined `UpdateUserCommand` with readonly typed properties:
  - `id`, `firstName`, `lastName`, `email`, `bio`, `location`, `skills`, `profileImage`
- Implemented static `build(Request $request): self` to construct the command from an HTTP request
- Added internal validation via `validation()` method
  - Throws `InvalidArgumentException` if required fields are missing
- Provides getter methods for each property

### Rationale

Introducing `UpdateUserCommand` allows the Application layer to maintain separation of concerns between HTTP-specific logic and core business logic.  
It ensures that only fully validated data is passed into the `UpdateOwnProfileUseCase`, improving testability, traceability, and type safety.