### PR TITLE
Add `UpdateUserDto` to represent updated user data in Application layer

### DIFF
--- a/.idea/workspace.xml
+++ b/.idea/workspace.xml
@@ -5,7 +5,10 @@
   </component>
   <component name="ChangeListManager">
     <list default="true" id="6952a861-17ec-40ad-b866-c564752c14a8" name="変更" comment="fix: test-environment-fix">
+      <change afterPath="$PROJECT_DIR$/src/app/User/Application/ApplicationTest/UpdateUserDtoTest.php" afterDir="false" />
+      <change afterPath="$PROJECT_DIR$/src/app/User/Application/Dto/UpdateUserDto.php" afterDir="false" />
       <change beforePath="$PROJECT_DIR$/.idea/workspace.xml" beforeDir="false" afterPath="$PROJECT_DIR$/.idea/workspace.xml" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/app/User/Application/ApplicationTest/ShowUserDtoTest.php" beforeDir="false" afterPath="$PROJECT_DIR$/src/app/User/Application/ApplicationTest/ShowUserDtoTest.php" afterDir="false" />
     </list>
     <option name="SHOW_DIALOG" value="false" />
     <option name="HIGHLIGHT_CONFLICTS" value="true" />
@@ -160,7 +163,7 @@
     "PHPUnit.メイン.executor": "Run",
     "RunOnceActivity.ShowReadmeOnStart": "true",
     "RunOnceActivity.git.unshallow": "true",
-    "git-widget-placeholder": "feature/edit-user-command",
+    "git-widget-placeholder": "feature/edit-user-application-dto",
     "node.js.detected.package.eslint": "true",
     "node.js.selected.package.eslint": "(autodetect)",
     "nodejs_package_manager_path": "npm",

--- a/src/app/User/Application/ApplicationTest/UpdateUserDtoTest.php
+++ b/src/app/User/Application/ApplicationTest/UpdateUserDtoTest.php
@@ -1,0 +1,113 @@
+<?php
+
+namespace App\User\Application\ApplicationTest;
+
+use Tests\TestCase;
+use App\User\Application\Dto\UpdateUserDto;
+use App\User\Domain\Entity\UserEntity;
+use App\User\Domain\ValueObject\Email;
+use App\Common\Domain\UserId;
+use Mockery;
+use App\User\Domain\Factory\UserUpdateEntityFactory;
+
+class UpdateUserDtoTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+    }
+
+    protected function tearDown(): void
+    {
+        parent::tearDown();
+    }
+
+    private function mockEntity(): UserEntity
+    {
+        $factory = Mockery::mock(
+            'alias' . UserUpdateEntityFactory::class
+        );
+
+        $entity = Mockery::mock(UserEntity::class);
+
+        $factory
+            ->shouldReceive('build')
+            ->andReturn($entity);
+
+        $entity
+            ->shouldReceive('getUserId')
+            ->andReturn(new UserId($this->arrayRequestData()['id']));
+
+        $entity
+            ->shouldReceive('getFirstName')
+            ->andReturn($this->arrayRequestData()['first_name']);
+
+        $entity
+            ->shouldReceive('getLastName')
+            ->andReturn($this->arrayRequestData()['last_name']);
+
+        $entity
+            ->shouldReceive('getEmail')
+            ->andReturn(new Email($this->arrayRequestData()['email']));
+
+        $entity
+            ->shouldReceive('getBio')
+            ->andReturn($this->arrayRequestData()['bio']);
+
+        $entity
+            ->shouldReceive('getLocation')
+            ->andReturn($this->arrayRequestData()['location']);
+
+        $entity
+            ->shouldReceive('getSkills')
+            ->andReturn($this->arrayRequestData()['skills']);
+
+        $entity
+            ->shouldReceive('getProfileImage')
+            ->andReturn($this->arrayRequestData()['profile_image']);
+
+        return $entity;
+    }
+
+    private function arrayRequestData(): array
+    {
+        return [
+            'id' => 1,
+            'first_name' => 'Cristiano',
+            'last_name' => 'Ronaldo',
+            'bio' => 'I am a football player',
+            'email' => 'manchester-united7@test.com',
+            'location' => null,
+            'skills' => [],
+            'profile_image' => 'https://example.com/profile.jpg',
+        ];
+    }
+
+    /**
+     * @test
+     * @testdox UpdateUserDtoTest_build_successfully check type
+     */
+    public function test1(): void
+    {
+        $result = UpdateUserDto::build($this->mockEntity());
+
+        $this->assertInstanceOf(UpdateUserDto::class, $result);
+    }
+
+    /**
+     * @test
+     * @testdox UpdateUserDtoTest_build_successfully check value
+     */
+    public function test2(): void
+    {
+        $result = UpdateUserDto::build($this->mockEntity());
+
+        $this->assertEquals($result->id, new UserId($this->arrayRequestData()['id']));
+        $this->assertEquals($result->firstName, $this->arrayRequestData()['first_name']);
+        $this->assertEquals($result->lastName, $this->arrayRequestData()['last_name']);
+        $this->assertEquals($result->bio, $this->arrayRequestData()['bio']);
+        $this->assertEquals($result->location, $this->arrayRequestData()['location']);
+        $this->assertEquals($result->skills, $this->arrayRequestData()['skills']);
+        $this->assertEquals($result->profileImage, $this->arrayRequestData()['profile_image']);
+    }
+}

--- a/src/app/User/Application/Dto/UpdateUserDto.php
+++ b/src/app/User/Application/Dto/UpdateUserDto.php
@@ -1,0 +1,78 @@
+<?php
+
+namespace App\User\Application\Dto;
+
+use App\Common\Domain\UserId;
+use App\User\Domain\Entity\UserEntity;
+use App\User\Domain\ValueObject\Email;
+
+class UpdateUserDto
+{
+    public function __construct(
+        public readonly UserId $id,
+        public readonly string $firstName,
+        public readonly string $lastName,
+        public readonly Email $email,
+        public readonly ?string $bio,
+        public readonly ?string $location,
+        public readonly array $skills,
+        public readonly ?string $profileImage
+    ) {
+    }
+
+    public function getId(): UserId
+    {
+        return $this->id;
+    }
+
+    public function getFirstName(): string
+    {
+        return $this->firstName;
+    }
+
+    public function getLastName(): string
+    {
+        return $this->lastName;
+    }
+
+    public function getEmail(): Email
+    {
+        return $this->email;
+    }
+
+    public function getBio(): ?string
+    {
+        return $this->bio ?? null;
+    }
+
+    public function getLocation(): ?string
+    {
+        return $this->location ?? null;
+    }
+
+    public function getSkills(): array
+    {
+        return $this->skills;
+    }
+
+    public function getProfileImage(): ?string
+    {
+        return $this->profileImage ?? null;
+    }
+
+    public static function build(
+        UserEntity $entity
+    ): self
+    {
+        return new self(
+            id: new UserId($entity->getUserId()->getValue()),
+            firstName: $entity->getFirstName(),
+            lastName: $entity->getLastName(),
+            email: $entity->getEmail(),
+            bio: $entity->getBio(),
+            location: $entity->getLocation(),
+            skills: $entity->getSkills(),
+            profileImage: $entity->getProfileImage()
+        );
+    }
+}


### PR DESCRIPTION
### Overview

This pull request introduces the `UpdateUserDto` class, which represents the updated state of a `UserEntity` within the Application layer.  
It is designed to carry domain-driven user data to the presentation layer after an update operation.

### Details

- Defined `UpdateUserDto` with the following readonly properties:
  - `UserId $id`
  - `string $firstName`, `string $lastName`
  - `Email $email`
  - `?string $bio`, `?string $location`, `?string $profileImage`
  - `array $skills`
- Added `build(UserEntity $entity): self` static factory method
- Provides individual getter methods for all properties
- Ensures consistent transformation from domain entity to DTO

### Rationale

This DTO serves as the output contract of the user profile update use case.  
It allows the presentation layer (e.g., controllers or view models) to consume updated user information in a structured, immutable, and type-safe manner.  
Encapsulating the mapping logic via a static `build()` method enhances clarity and reusability.