### PR TITLE
 Add `UpdateUseCase` to handle user update logic via `UpdateUserCommand`

### DIFF
--- a/.idea/workspace.xml
+++ b/.idea/workspace.xml
@@ -5,10 +5,11 @@
   </component>
   <component name="ChangeListManager">
     <list default="true" id="6952a861-17ec-40ad-b866-c564752c14a8" name="変更" comment="fix: test-environment-fix">
-      <change afterPath="$PROJECT_DIR$/src/app/User/Application/ApplicationTest/UpdateUserDtoTest.php" afterDir="false" />
-      <change afterPath="$PROJECT_DIR$/src/app/User/Application/Dto/UpdateUserDto.php" afterDir="false" />
+      <change afterPath="$PROJECT_DIR$/src/app/User/Application/ApplicationTest/UpdateUserUseCaseTest.php" afterDir="false" />
       <change beforePath="$PROJECT_DIR$/.idea/workspace.xml" beforeDir="false" afterPath="$PROJECT_DIR$/.idea/workspace.xml" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/src/app/User/Application/ApplicationTest/ShowUserDtoTest.php" beforeDir="false" afterPath="$PROJECT_DIR$/src/app/User/Application/ApplicationTest/ShowUserDtoTest.php" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/app/User/Application/UseCommand/UpdateUserCommand.php" beforeDir="false" afterPath="$PROJECT_DIR$/src/app/User/Application/UseCommand/UpdateUserCommand.php" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/app/User/Domain/Factory/UserUpdateEntityFactory.php" beforeDir="false" afterPath="$PROJECT_DIR$/src/app/User/Domain/Factory/UserUpdateEntityFactory.php" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/app/User/Infrastructure/Repository/UserRepository.php" beforeDir="false" afterPath="$PROJECT_DIR$/src/app/User/Infrastructure/Repository/UserRepository.php" afterDir="false" />
     </list>
     <option name="SHOW_DIALOG" value="false" />
     <option name="HIGHLIGHT_CONFLICTS" value="true" />
@@ -163,7 +164,7 @@
     "PHPUnit.メイン.executor": "Run",
     "RunOnceActivity.ShowReadmeOnStart": "true",
     "RunOnceActivity.git.unshallow": "true",
-    "git-widget-placeholder": "feature/edit-user-application-dto",
+    "git-widget-placeholder": "feature/edit-user-usecase",
     "node.js.detected.package.eslint": "true",
     "node.js.selected.package.eslint": "(autodetect)",
     "nodejs_package_manager_path": "npm",

--- a/src/app/User/Application/ApplicationTest/UpdateUserUseCaseTest.php
+++ b/src/app/User/Application/ApplicationTest/UpdateUserUseCaseTest.php
@@ -1,0 +1,255 @@
+<?php
+
+namespace App\User\Application\UseCase;
+
+use App\Common\Domain\UserId;
+use App\User\Domain\Factory\UserFromModelEntityFactory;
+use App\User\Domain\Factory\UserUpdateEntityFactory;
+use App\User\Domain\ValueObject\Email;
+use Tests\TestCase;
+use Mockery;
+use App\User\Application\UseCommand\UpdateUserCommand;
+use App\User\Application\Dto\UpdateUserDto;
+use App\User\Domain\RepositoryInterface\UserRepositoryInterface;
+use App\User\Domain\Entity\UserEntity;
+
+class UpdateUserUseCaseTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+    }
+
+    protected function tearDown(): void
+    {
+        parent::tearDown();
+    }
+
+    private function mockUseCommand(): UpdateUserCommand
+    {
+        $command = Mockery::mock(UpdateUserCommand::class);
+
+        $command
+            ->shouldReceive('getId')
+            ->andReturn($this->arrayData()['id']);
+
+        $command
+            ->shouldReceive('getFirstName')
+            ->andReturn($this->arrayData()['first_name']);
+
+        $command
+            ->shouldReceive('getLastName')
+            ->andReturn($this->arrayData()['last_name']);
+
+        $command
+            ->shouldReceive('getEmail')
+            ->andReturn($this->arrayData()['email']);
+
+        $command
+            ->shouldReceive('getBio')
+            ->andReturn($this->arrayData()['bio']);
+
+        $command
+            ->shouldReceive('getLocation')
+            ->andReturn($this->arrayData()['location']);
+
+        $command
+            ->shouldReceive('getSkills')
+            ->andReturn($this->arrayData()['skills']);
+
+        $command
+            ->shouldReceive('getProfileImage')
+            ->andReturn($this->arrayData()['profile_image']);
+
+        $command
+            ->shouldReceive('toArray')
+            ->andReturn($this->arrayData());
+
+        return $command;
+    }
+
+    private function mockUserUpdateEntityFactory(): void
+    {
+        $factory = Mockery::mock('alias:' . UserUpdateEntityFactory::class);
+
+        $factory
+            ->shouldReceive('build')
+            ->with(Mockery::on(function ($arg) {
+                return $arg instanceof UpdateUserCommand;
+            }))
+            ->andReturn($this->mockEntity());
+    }
+
+    private function mockModelEntityFactory(): void
+    {
+        $factory = Mockery::mock('alias:' . UserFromModelEntityFactory::class);
+
+        $factory
+            ->shouldReceive('buildFromModel')
+            ->with(Mockery::on(function ($arg) {
+                return $arg instanceof UserEntity;
+            }))
+            ->andReturn($this->mockEntity());
+    }
+
+    private function mockEntity(): UserEntity
+    {
+        $factory = Mockery::mock('alias:' . UserUpdateEntityFactory::class);
+
+        $entity = Mockery::mock(UserEntity::class);
+
+        $factory
+            ->shouldReceive('build')
+            ->with(Mockery::on(function ($arg) {
+                return $arg instanceof UpdateUserCommand;
+            }))
+            ->andReturn(Mockery::on(UserEntity::class));
+
+        $entity
+            ->shouldReceive('getUserId')
+            ->andReturn(new UserId($this->arrayData()['id']));
+
+        $entity
+            ->shouldReceive('getFirstName')
+            ->andReturn($this->arrayData()['first_name']);
+
+        $entity
+            ->shouldReceive('getLastName')
+            ->andReturn($this->arrayData()['last_name']);
+
+        $entity
+            ->shouldReceive('getEmail')
+            ->andReturn(new Email($this->arrayData()['email']));
+
+        $entity
+            ->shouldReceive('getBio')
+            ->andReturn($this->arrayData()['bio']);
+
+        $entity
+            ->shouldReceive('getLocation')
+            ->andReturn($this->arrayData()['location']);
+
+        $entity
+            ->shouldReceive('getSkills')
+            ->andReturn($this->arrayData()['skills']);
+
+        $entity
+            ->shouldReceive('getProfileImage')
+            ->andReturn($this->arrayData()['profile_image']);
+
+        return $entity;
+    }
+
+    private function mockDto(): UpdateUserDto
+    {
+        $dto = Mockery::mock(UpdateUserDto::class);
+
+        $dto
+            ->shouldReceive('getId')
+            ->andReturn($this->arrayData()['id']);
+
+        $dto
+            ->shouldReceive('getFirstName')
+            ->andReturn($this->arrayData()['first_name']);
+
+        $dto
+            ->shouldReceive('getLastName')
+            ->andReturn($this->arrayData()['last_name']);
+
+        $dto
+            ->shouldReceive('getEmail')
+            ->andReturn($this->arrayData()['email']);
+
+        $dto
+            ->shouldReceive('getBio')
+            ->andReturn($this->arrayData()['bio']);
+
+        $dto
+            ->shouldReceive('getLocation')
+            ->andReturn($this->arrayData()['location']);
+
+        $dto
+            ->shouldReceive('getSkills')
+            ->andReturn($this->arrayData()['skills']);
+
+        $dto
+            ->shouldReceive('getProfileImage')
+            ->andReturn($this->arrayData()['profile_image']);
+
+        return $dto;
+    }
+
+    private function mockRepository()
+    {
+        $repository = Mockery::mock(UserRepositoryInterface::class);
+
+        $repository
+            ->shouldReceive('update')
+            ->with(Mockery::on(function ($arg) {
+                return $arg instanceof UserEntity;
+            }))
+            ->andReturn($this->mockEntity());
+
+        return $repository;
+    }
+
+    private function arrayData(): array
+    {
+        return [
+            'id' => 1,
+            'first_name' => 'Cristiano',
+            'last_name' => 'Ronaldo',
+            'bio' => 'I am a football player',
+            'email' => 'manchester-united7@test.com',
+            'location' => null,
+            'skills' => [],
+            'profile_image' => 'https://example.com/profile.jpg',
+        ];
+    }
+
+    /**
+     * @test
+     */
+    public function test1(): void
+    {
+        $this->mockUserUpdateEntityFactory();
+        $this->mockModelEntityFactory();
+
+        $useCase = new UpdateUseCase(
+            $this->mockRepository(),
+        );
+
+        $result = $useCase->handle(
+            $this->mockUseCommand(),
+        );
+
+        $this->assertInstanceOf(UpdateUserDto::class, $result);
+    }
+
+    /**
+     * @test
+     * @testdox UpdateUserUseCaseTest_update_user_successfully
+     */
+    public function test2(): void
+    {
+        $this->mockUserUpdateEntityFactory();
+        $this->mockModelEntityFactory();
+
+        $useCase = new UpdateUseCase(
+            $this->mockRepository(),
+        );
+
+        $result = $useCase->handle(
+            $this->mockUseCommand(),
+        );
+
+        $this->assertEquals($result->getId(), new UserId($this->arrayData()['id']));
+        $this->assertEquals($result->getFirstName(), $this->arrayData()['first_name']);
+        $this->assertEquals($result->getLastName(), $this->arrayData()['last_name']);
+        $this->assertEquals($result->getEmail(), new Email($this->arrayData()['email']));
+        $this->assertEquals($result->getBio(), $this->arrayData()['bio']);
+        $this->assertEquals($result->getLocation(), $this->arrayData()['location']);
+        $this->assertEquals($result->getSkills(), $this->arrayData()['skills']);
+        $this->assertEquals($result->getProfileImage(), $this->arrayData()['profile_image']);
+    }
+}

--- a/src/app/User/Application/UseCase/UpdateUseCase.php
+++ b/src/app/User/Application/UseCase/UpdateUseCase.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace App\User\Application\UseCase;
+
+use App\User\Application\Dto\UpdateUserDto;
+use App\User\Application\UseCommand\UpdateUserCommand;
+use App\User\Domain\Factory\UserUpdateEntityFactory;
+use App\User\Domain\RepositoryInterface\UserRepositoryInterface;
+
+class UpdateUseCase
+{
+    public function __construct(
+        readonly private UserRepositoryInterface $repository,
+    ) {
+    }
+
+    public function handle(
+        UpdateUserCommand $command
+    ): UpdateUserDto
+    {
+        $entity = UserUpdateEntityFactory::build(
+            $command
+        );
+
+        $result = $this->repository->update($entity);
+
+        return UpdateUserDto::build($result);
+    }
+}

--- a/src/app/User/Application/UseCommand/UpdateUserCommand.php
+++ b/src/app/User/Application/UseCommand/UpdateUserCommand.php
@@ -103,4 +103,17 @@ class UpdateUserCommand
         'skills',
         'profile_image'
     ];
+
+    public function toArray(): array
+    {
+        return [
+            'id' => $this->getId(),
+            'first_name' => $this->getFirstName(),
+            'last_name' => $this->getLastName(),
+            'bio' => $this->getBio(),
+            'location' => $this->getLocation(),
+            'skills' => $this->getSkills(),
+            'profile_image' => $this->getProfileImage(),
+        ];
+    }
 }

--- a/src/app/User/Domain/DomainTest/UserUpdateEntityFactoryTest.php
+++ b/src/app/User/Domain/DomainTest/UserUpdateEntityFactoryTest.php
@@ -2,6 +2,7 @@
 
 namespace App\User\Domain\DomainTest;
 
+use App\User\Application\UseCommand\UpdateUserCommand;
 use Mockery;
 use Tests\TestCase;
 use App\User\Domain\Entity\UserEntity;
@@ -36,43 +37,43 @@ class UserUpdateEntityFactoryTest extends TestCase
         ];
     }
 
-    private function mockEntity(): UserEntity
+    private function mockCommand(): UpdateUserCommand
     {
-        $entity = Mockery::mock(UserEntity::class);
+        $command = Mockery::mock(UpdateUserCommand::class);
 
-        $entity
-            ->shouldReceive('getUserId')
-            ->andReturn(new UserId($this->arrayRequestData()['id']));
+        $command
+            ->shouldReceive('getId')
+            ->andReturn($this->arrayRequestData()['id']);
 
-        $entity
+        $command
             ->shouldReceive('getFirstName')
             ->andReturn($this->arrayRequestData()['first_name']);
 
-        $entity
+        $command
             ->shouldReceive('getLastName')
             ->andReturn($this->arrayRequestData()['last_name']);
 
-        $entity
+        $command
             ->shouldReceive('getEmail')
-            ->andReturn(new Email($this->arrayRequestData()['email']));
+            ->andReturn($this->arrayRequestData()['email']);
 
-        $entity
+        $command
             ->shouldReceive('getBio')
             ->andReturn($this->arrayRequestData()['bio']);
 
-        $entity
+        $command
             ->shouldReceive('getLocation')
             ->andReturn($this->arrayRequestData()['location']);
 
-        $entity
+        $command
             ->shouldReceive('getSkills')
             ->andReturn($this->arrayRequestData()['skills']);
 
-        $entity
+        $command
             ->shouldReceive('getProfileImage')
             ->andReturn($this->arrayRequestData()['profile_image']);
 
-        return $entity;
+        return $command;
     }
 
     /**
@@ -81,7 +82,7 @@ class UserUpdateEntityFactoryTest extends TestCase
      */
     public function test1(): void
     {
-        $result = UserUpdateEntityFactory::build($this->mockEntity());
+        $result = UserUpdateEntityFactory::build($this->mockCommand());
 
         $this->assertInstanceOf(UserEntity::class, $result);
     }
@@ -92,7 +93,7 @@ class UserUpdateEntityFactoryTest extends TestCase
      */
     public function test2(): void
     {
-        $result = UserUpdateEntityFactory::build($this->mockEntity());
+        $result = UserUpdateEntityFactory::build($this->mockCommand());
 
         $this->assertEquals($result->getFirstName(), $this->arrayRequestData()['first_name']);
         $this->assertEquals($result->getLastName(), $this->arrayRequestData()['last_name']);
@@ -120,41 +121,41 @@ class UserUpdateEntityFactoryTest extends TestCase
             'profile_image' => 'https://example.com/profile.jpg',
         ];
 
-        $partiallyEntity = Mockery::mock(UserEntity::class);
+        $partiallyCommand = Mockery::mock(UpdateUserCommand::class);
 
-        $partiallyEntity
-            ->shouldReceive('getUserId')
-            ->andReturn(new UserId($partiallyData['id']));
+        $partiallyCommand
+            ->shouldReceive('getId')
+            ->andReturn($partiallyData['id']);
 
-        $partiallyEntity
+        $partiallyCommand
             ->shouldReceive('getFirstName')
             ->andReturn($partiallyData['first_name']);
 
-        $partiallyEntity
+        $partiallyCommand
             ->shouldReceive('getLastName')
             ->andReturn($partiallyData['last_name']);
 
-        $partiallyEntity
+        $partiallyCommand
             ->shouldReceive('getEmail')
-            ->andReturn(new Email($partiallyData['email']));
+            ->andReturn($partiallyData['email']);
 
-        $partiallyEntity
+        $partiallyCommand
             ->shouldReceive('getBio')
             ->andReturn(null);
 
-        $partiallyEntity
+        $partiallyCommand
             ->shouldReceive('getLocation')
             ->andReturn($partiallyData['location']);
 
-        $partiallyEntity
-            ->shouldReceive('getSkills')
-            ->andReturn($partiallyData['skills']);
-
-        $partiallyEntity
+        $partiallyCommand
             ->shouldReceive('getProfileImage')
             ->andReturn($partiallyData['profile_image']);
 
-        $result = UserUpdateEntityFactory::build($partiallyEntity);
+        $partiallyCommand
+            ->shouldReceive('getSkills')
+            ->andReturn($partiallyData['skills']);
+
+        $result = UserUpdateEntityFactory::build($partiallyCommand);
 
         $this->assertEquals($result->getFirstName(), $partiallyData['first_name']);
         $this->assertEquals($result->getLastName(), $partiallyData['last_name']);

--- a/src/app/User/Domain/Factory/UserUpdateEntityFactory.php
+++ b/src/app/User/Domain/Factory/UserUpdateEntityFactory.php
@@ -13,15 +13,17 @@ class UserUpdateEntityFactory
         UpdateUserCommand $command
     ): UserEntity
     {
+        $commandArray = $command->toArray();
+
         return new UserEntity(
-            id: new Userid($command->getId()),
-            firstName: $command->getFirstName(),
-            lastName: $command->getLastName(),
-            email: new Email($command->getEmail()),
-            bio: $command->getBio(),
-            location: $command->getLocation(),
-            skills: $command->getSkills(),
-            profileImage: $command->getProfileImage()
+            id: new UserId($commandArray['id']),
+            firstName: $commandArray['first_name'],
+            lastName: $commandArray['last_name'],
+            email: new Email($commandArray['email']),
+            bio: isset($commandArray['bio']) ? $commandArray['bio'] : null,
+            location: isset($commandArray['location']) ? $commandArray['location'] : null,
+            skills: isset($commandArray['skills']) ? $commandArray['skills'] : [],
+            profileImage: isset($commandArray['profile_image']) ? $commandArray['profile_image'] : null
         );
     }
 }

--- a/src/app/User/Domain/Factory/UserUpdateEntityFactory.php
+++ b/src/app/User/Domain/Factory/UserUpdateEntityFactory.php
@@ -2,23 +2,26 @@
 
 namespace App\User\Domain\Factory;
 
+use App\User\Application\UseCommand\UpdateUserCommand;
 use App\User\Domain\Entity\UserEntity;
 use App\Common\Domain\UserId;
 use App\User\Domain\ValueObject\Email;
 
 class UserUpdateEntityFactory
 {
-    public static function build(UserEntity $entity): UserEntity
+    public static function build(
+        UpdateUserCommand $command
+    ): UserEntity
     {
         return new UserEntity(
-            id: new Userid($entity->getUserId()?->getValue()),
-            firstName: $entity->getFirstName(),
-            lastName: $entity->getLastName(),
-            email: new Email($entity->getEmail()->getValue()),
-            bio: $entity->getBio() ?? null,
-            location: $entity->getLocation() ?? null,
-            skills: $entity->getSkills() ?? [],
-            profileImage: $entity->getProfileImage() ?? null,
+            id: new Userid($command->getId()),
+            firstName: $command->getFirstName(),
+            lastName: $command->getLastName(),
+            email: new Email($command->getEmail()),
+            bio: $command->getBio(),
+            location: $command->getLocation(),
+            skills: $command->getSkills(),
+            profileImage: $command->getProfileImage()
         );
     }
 }

--- a/src/app/User/Infrastructure/Repository/UserRepository.php
+++ b/src/app/User/Infrastructure/Repository/UserRepository.php
@@ -6,7 +6,6 @@ use App\Common\Domain\UserId;
 use App\Models\User;
 use App\User\Domain\Entity\UserEntity;
 use App\User\Domain\Factory\UserFromModelEntityFactory;
-use App\User\Domain\Factory\UserUpdateEntityFactory;
 use App\User\Domain\RepositoryInterface\UserRepositoryInterface;
 use App\User\Domain\ValueObject\Email;
 use App\User\Domain\RepositoryInterface\PasswordHasherInterface;
@@ -16,7 +15,8 @@ use Exception;
 class UserRepository implements UserRepositoryInterface
 {
     public function __construct(
-        private readonly PasswordHasherInterface $hasher
+        private readonly PasswordHasherInterface $hasher,
+        private readonly User $user
     ) {}
 
     public function save(UserEntity $entity): ?UserEntity
@@ -25,7 +25,7 @@ class UserRepository implements UserRepositoryInterface
             ? $entity->getPassword()->getHashedPassword()
             : throw new LogicException('Password is missing.');
 
-        $model = User::create([
+        $model = $this->user->create([
             'first_name' => $entity->getFirstName(),
             'last_name' => $entity->getLastName(),
             'email' => $entity->getEmail()->getValue(),
@@ -41,12 +41,12 @@ class UserRepository implements UserRepositoryInterface
 
     public function existsByEmail(Email $email): bool
     {
-        return User::where('email', $email->getValue())->exists();
+        return $this->user->where('email', $email->getValue())->exists();
     }
 
     public function findById(UserId $id): UserEntity
     {
-        $findUser = User::find($id->getValue());
+        $findUser = $this->user->find($id->getValue());
 
         if ($findUser === null) {
             throw new Exception('User not found');
@@ -59,12 +59,25 @@ class UserRepository implements UserRepositoryInterface
         UserEntity $entity
     ): UserEntity
     {
-        $targetUser = User::find($entity->getUserId()->getValue());
+        $targetUser = $this->user->findById($entity->getUserId());
 
         if ($targetUser === null) {
             throw new Exception('User not found');
         }
 
-        return UserUpdateEntityFactory::build($entity);
+        $this->user->update(
+            [
+                'id' => $targetUser->id,
+                'first_name' => $entity->getFirstName(),
+                'last_name' => $entity->getLastName(),
+                'email' => $entity->getEmail()->getValue(),
+                'bio' => $entity->getBio(),
+                'location' => $entity->getLocation(),
+                'skills' => json_encode($entity->getSkills()),
+                'profile_image' => $entity->getProfileImage()
+            ]
+        );
+
+        return UserFromModelEntityFactory::buildFromModel($this->user->find($entity->getUserId()->getValue()));
     }
 }


### PR DESCRIPTION
## Description

This pull request introduces the `UpdateUseCase` class which is responsible for handling user update operations.

The use case receives an `UpdateUserCommand`, constructs a domain entity via `UserUpdateEntityFactory`, delegates the persistence to `UserRepositoryInterface::update()`, and finally returns a `UpdateUserDto` built from the result.

### Summary of changes:
- Introduced `UpdateUseCase` class
- Injected `UserRepositoryInterface` via constructor
- Connected `UserUpdateEntityFactory` and `UpdateUserDto` within the use case flow