### PR TITLE
Add `UpdateUserViewModel` to format update response data for presentation

### DIFF
--- a/.idea/workspace.xml
+++ b/.idea/workspace.xml
@@ -5,11 +5,9 @@
   </component>
   <component name="ChangeListManager">
     <list default="true" id="6952a861-17ec-40ad-b866-c564752c14a8" name="変更" comment="fix: test-environment-fix">
-      <change afterPath="$PROJECT_DIR$/src/app/User/Application/ApplicationTest/UpdateUserUseCaseTest.php" afterDir="false" />
+      <change afterPath="$PROJECT_DIR$/src/app/User/Presentation/PresentationTest/UpdateUserViewModelTest.php" afterDir="false" />
+      <change afterPath="$PROJECT_DIR$/src/app/User/Presentation/ViewModel/UpdateUserViewModel.php" afterDir="false" />
       <change beforePath="$PROJECT_DIR$/.idea/workspace.xml" beforeDir="false" afterPath="$PROJECT_DIR$/.idea/workspace.xml" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/src/app/User/Application/UseCommand/UpdateUserCommand.php" beforeDir="false" afterPath="$PROJECT_DIR$/src/app/User/Application/UseCommand/UpdateUserCommand.php" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/src/app/User/Domain/Factory/UserUpdateEntityFactory.php" beforeDir="false" afterPath="$PROJECT_DIR$/src/app/User/Domain/Factory/UserUpdateEntityFactory.php" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/src/app/User/Infrastructure/Repository/UserRepository.php" beforeDir="false" afterPath="$PROJECT_DIR$/src/app/User/Infrastructure/Repository/UserRepository.php" afterDir="false" />
     </list>
     <option name="SHOW_DIALOG" value="false" />
     <option name="HIGHLIGHT_CONFLICTS" value="true" />
@@ -164,7 +162,7 @@
     "PHPUnit.メイン.executor": "Run",
     "RunOnceActivity.ShowReadmeOnStart": "true",
     "RunOnceActivity.git.unshallow": "true",
-    "git-widget-placeholder": "feature/edit-user-usecase",
+    "git-widget-placeholder": "feature/edit-user-viewmodel",
     "node.js.detected.package.eslint": "true",
     "node.js.selected.package.eslint": "(autodetect)",
     "nodejs_package_manager_path": "npm",

--- a/src/.gitignore
+++ b/src/.gitignore
@@ -22,3 +22,4 @@ yarn-error.log
 /.nova
 /.vscode
 /.zed
+.idea/workspace.xml

--- a/src/app/User/Presentation/PresentationTest/UpdateUserViewModelTest.php
+++ b/src/app/User/Presentation/PresentationTest/UpdateUserViewModelTest.php
@@ -1,0 +1,102 @@
+<?php
+
+namespace App\User\Presentation\PresentationTest;
+
+use App\Common\Domain\UserId;
+use App\User\Application\Dto\UpdateUserDto;
+use App\User\Domain\ValueObject\Email;
+use App\User\Presentation\ViewModel\UpdateUserViewModel;
+use Tests\TestCase;
+use Mockery;
+
+class UpdateUserViewModelTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+    }
+
+    protected function tearDown(): void
+    {
+        parent::tearDown();
+    }
+
+    private function mockDto(): UpdateUserDto
+    {
+        $dto = Mockery::mock(UpdateUserDto::class);
+
+        $dto
+            ->shouldReceive('getId')
+            ->andReturn(new Userid($this->arrayRequestData()['id']));
+
+        $dto
+            ->shouldReceive('getFirstName')
+            ->andReturn($this->arrayRequestData()['first_name']);
+
+        $dto
+            ->shouldReceive('getLastName')
+            ->andReturn($this->arrayRequestData()['last_name']);
+
+        $dto
+            ->shouldReceive('getEmail')
+            ->andReturn(new Email($this->arrayRequestData()['email']));
+
+        $dto
+            ->shouldReceive('getBio')
+            ->andReturn($this->arrayRequestData()['bio']);
+
+        $dto
+            ->shouldReceive('getProfileImage')
+            ->andReturn($this->arrayRequestData()['profile_image']);
+
+        $dto
+            ->shouldReceive('getLocation')
+            ->andReturn($this->arrayRequestData()['location']);
+
+        $dto
+            ->shouldReceive('getSkills')
+            ->andReturn($this->arrayRequestData()['skills']);
+
+        return $dto;
+    }
+
+    private function arrayRequestData(): array
+    {
+        return [
+            'id' => 1,
+            'first_name' => 'zinedine',
+            'last_name' => 'zidane',
+            'email' => 'france10@test.com',
+            'bio' => 'I am a football player',
+            'location' => 'France',
+            'skills' => ['football', 'coaching'],
+            'profile_image' => 'https://example.com/image.jpg',
+        ];
+    }
+
+    public function test1(): void
+    {
+        $result = UpdateUserViewModel::buildFromDto($this->mockDto());
+
+        $this->assertInstanceOf(UpdateUserViewModel::class, $result);
+    }
+
+    /**
+     * @test
+     * @testdox ShowUserViewModelTest_build_successfully check value
+     */
+    public function test2(): void
+    {
+        $result = UpdateUserViewModel::buildFromDto($this->mockDto())->toArray();
+
+        $expectedFullName = $this->arrayRequestData()['first_name'] . ' ' . $this->arrayRequestData()['last_name'];
+
+        $this->assertEquals($this->arrayRequestData()['id'], $result['id']);
+        $this->assertEquals($expectedFullName, $result['full_name']);
+        $this->assertEquals($this->arrayRequestData()['email'], $result['email']);
+        $this->assertEquals($this->arrayRequestData()['bio'], $result['bio']);
+        $this->assertEquals($this->arrayRequestData()['location'], $result['location']);
+        $this->assertEquals($this->arrayRequestData()['skills'], $result['skills']);
+        $this->assertEquals($this->arrayRequestData()['profile_image'], $result['profile_image']);
+    }
+}

--- a/src/app/User/Presentation/ViewModel/UpdateUserViewModel.php
+++ b/src/app/User/Presentation/ViewModel/UpdateUserViewModel.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace App\User\Presentation\ViewModel;
+
+use App\User\Application\Dto\UpdateUserDto;
+
+class UpdateUserViewModel
+{
+    public function __construct(
+        public readonly int $id,
+        public readonly string $fullName,
+        public readonly string $email,
+        public readonly ?string $bio,
+        public readonly ?string $location,
+        public readonly array $skills,
+        public readonly ?string $profileImage,
+    ) {}
+
+    public static function buildFromDto(UpdateUserDto $dto): self
+    {
+        return new self(
+            id: $dto->getId()->getValue(),
+            fullName: $dto->getFirstName() . ' ' . $dto->getLastName(),
+            email: $dto->getEmail()->getValue(),
+            bio: $dto->getBio(),
+            location: $dto->getLocation(),
+            skills: $dto->getSkills(),
+            profileImage: $dto->getProfileImage(),
+        );
+    }
+
+    public function toArray(): array
+    {
+        return [
+            'id' => $this->id,
+            'full_name' => $this->fullName,
+            'email' => $this->email,
+            'bio' => $this->bio ?? '',
+            'location' => $this->location ?? '',
+            'skills' => $this->skills,
+            'profile_image' => $this->profileImage ?? ''
+        ];
+    }
+}


### PR DESCRIPTION
## Description

This pull request introduces the `UpdateUserViewModel` class, which is responsible for converting `UpdateUserDto` into a serialisable format suitable for API responses or frontend consumption.

The ViewModel encapsulates output logic and ensures that null fields are safely handled, and compound values (e.g. `full_name`) are derived in the presentation layer.

### Summary of changes:
- Added `UpdateUserViewModel` with readonly properties
- Implemented `buildFromDto(UpdateUserDto $dto)` static factory method
- Implemented `toArray()` method for serialisation
- Includes logic to normalise null values and derive `full_name`