### PR TITLE
Define `AuthServiceInterface` for domain-level authentication contract

### DIFF
--- a/.idea/workspace.xml
+++ b/.idea/workspace.xml
@@ -5,9 +5,7 @@
   </component>
   <component name="ChangeListManager">
     <list default="true" id="6952a861-17ec-40ad-b866-c564752c14a8" name="変更" comment="fix: test-environment-fix">
-      <change afterPath="$PROJECT_DIR$/src/app/User/Domain/DomainTest/UserLoginEntityFactoryTest.php" afterDir="false" />
-      <change afterPath="$PROJECT_DIR$/src/app/User/Domain/Factory/UserLoginEntityFactory.php" afterDir="false" />
-      <change afterPath="$PROJECT_DIR$/src/app/User/Domain/ValueObject/AuthToken.php" afterDir="false" />
+      <change afterPath="$PROJECT_DIR$/src/app/User/Domain/Service/AuthServiceInterface.php" afterDir="false" />
       <change beforePath="$PROJECT_DIR$/.idea/workspace.xml" beforeDir="false" afterPath="$PROJECT_DIR$/.idea/workspace.xml" afterDir="false" />
     </list>
     <option name="SHOW_DIALOG" value="false" />
@@ -163,13 +161,18 @@
     "PHPUnit.メイン.executor": "Run",
     "RunOnceActivity.ShowReadmeOnStart": "true",
     "RunOnceActivity.git.unshallow": "true",
-    "git-widget-placeholder": "feature/user-login-domain-valueobject",
+    "git-widget-placeholder": "feature/user-login-authservice-interface",
     "node.js.detected.package.eslint": "true",
     "node.js.selected.package.eslint": "(autodetect)",
     "nodejs_package_manager_path": "npm",
     "settings.editor.selected.configurable": "Settings.JavaScript"
   }
 }]]></component>
+  <component name="RecentsManager">
+    <key name="MoveFile.RECENT_KEYS">
+      <recent name="$PROJECT_DIR$/src/app/User/Domain/Service" />
+    </key>
+  </component>
   <component name="RunManager">
     <configuration name="メイン" type="PHPUnitRunConfigurationType" factoryName="PHPUnit">
       <TestRunner configuration_file="$PROJECT_DIR$/src/phpunit.xml" scope="XML" use_alternative_configuration_file="true" />

--- a/src/app/User/Domain/Service/AuthServiceInterface.php
+++ b/src/app/User/Domain/Service/AuthServiceInterface.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace App\User\Domain\Service;
+
+use App\User\Domain\Entity\UserEntity;
+use App\User\Domain\ValueObject\Email;
+use App\User\Domain\ValueObject\Password;
+
+interface AuthServiceInterface
+{
+    public function attemptLogin(
+        Email $email,
+        Password $password
+    )
+    : ?UserEntity;
+}


### PR DESCRIPTION
### Description

Introduced `AuthServiceInterface` under the `App\User\Domain\Service` namespace to define a domain-level contract for authentication behaviour.  
This interface allows decoupling the login logic from any specific implementation such as JWT, session-based auth, or external providers.

### Changes

- Created interface `AuthServiceInterface`
- Declared method `attemptLogin(Email $email, Password $password): ?UserEntity`
- Placed under `App\User\Domain\Service`, following domain-layer abstraction conventions