### PR TITLE
Define `GenerateTokenInterface` for token issuance abstraction

### DIFF
--- a/.idea/workspace.xml
+++ b/.idea/workspace.xml
@@ -5,7 +5,6 @@
   </component>
   <component name="ChangeListManager">
     <list default="true" id="6952a861-17ec-40ad-b866-c564752c14a8" name="変更" comment="fix: test-environment-fix">
-      <change afterPath="$PROJECT_DIR$/src/app/User/Domain/Service/AuthServiceInterface.php" afterDir="false" />
       <change beforePath="$PROJECT_DIR$/.idea/workspace.xml" beforeDir="false" afterPath="$PROJECT_DIR$/.idea/workspace.xml" afterDir="false" />
     </list>
     <option name="SHOW_DIALOG" value="false" />
@@ -161,7 +160,7 @@
     "PHPUnit.メイン.executor": "Run",
     "RunOnceActivity.ShowReadmeOnStart": "true",
     "RunOnceActivity.git.unshallow": "true",
-    "git-widget-placeholder": "feature/user-login-authservice-interface",
+    "git-widget-placeholder": "feature/user-login-domain",
     "node.js.detected.package.eslint": "true",
     "node.js.selected.package.eslint": "(autodetect)",
     "nodejs_package_manager_path": "npm",

--- a/src/app/User/Domain/Service/GenerateTokenInterface.php
+++ b/src/app/User/Domain/Service/GenerateTokenInterface.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace App\User\Domain\Service;
+
+use App\User\Domain\Entity\UserEntity;
+use App\User\Domain\ValueObject\AuthToken;
+
+interface GenerateTokenInterface
+{
+    /**
+     *
+     * @param UserEntity $user
+     * @return AuthToken
+     */
+    public function issue(UserEntity $user): AuthToken;
+}


### PR DESCRIPTION
### Description

Introduced the `GenerateTokenInterface` to define a domain-level contract for issuing authentication tokens (e.g., JWT) for authenticated users.  
This interface ensures that token generation logic remains decoupled from domain logic and can be implemented flexibly in the infrastructure layer.

### Changes

- Created `GenerateTokenInterface` under `App\User\Domain\Service`
- Declared method `issue(UserEntity $user): AuthToken`
- The return value is strongly typed using the `AuthToken` value object
- Input is a fully authenticated `UserEntity`, ensuring token is issued only after successful login
