### PR TITLE
Define `GenerateTokenInterface` in User Login Domain layer

### DIFF
--- a/.idea/workspace.xml
+++ b/.idea/workspace.xml
@@ -5,9 +5,7 @@
   </component>
   <component name="ChangeListManager">
     <list default="true" id="6952a861-17ec-40ad-b866-c564752c14a8" name="変更" comment="fix: test-environment-fix">
-      <change afterPath="$PROJECT_DIR$/src/app/User/Domain/DomainTest/UserLoginEntityFactoryTest.php" afterDir="false" />
-      <change afterPath="$PROJECT_DIR$/src/app/User/Domain/Factory/UserLoginEntityFactory.php" afterDir="false" />
-      <change afterPath="$PROJECT_DIR$/src/app/User/Domain/ValueObject/AuthToken.php" afterDir="false" />
+      <change afterPath="$PROJECT_DIR$/src/app/User/Domain/Service/AuthServiceInterface.php" afterDir="false" />
       <change beforePath="$PROJECT_DIR$/.idea/workspace.xml" beforeDir="false" afterPath="$PROJECT_DIR$/.idea/workspace.xml" afterDir="false" />
     </list>
     <option name="SHOW_DIALOG" value="false" />
@@ -163,13 +161,18 @@
     "PHPUnit.メイン.executor": "Run",
     "RunOnceActivity.ShowReadmeOnStart": "true",
     "RunOnceActivity.git.unshallow": "true",
-    "git-widget-placeholder": "feature/user-login-domain-valueobject",
+    "git-widget-placeholder": "feature/user-login-authservice-interface",
     "node.js.detected.package.eslint": "true",
     "node.js.selected.package.eslint": "(autodetect)",
     "nodejs_package_manager_path": "npm",
     "settings.editor.selected.configurable": "Settings.JavaScript"
   }
 }]]></component>
+  <component name="RecentsManager">
+    <key name="MoveFile.RECENT_KEYS">
+      <recent name="$PROJECT_DIR$/src/app/User/Domain/Service" />
+    </key>
+  </component>
   <component name="RunManager">
     <configuration name="メイン" type="PHPUnitRunConfigurationType" factoryName="PHPUnit">
       <TestRunner configuration_file="$PROJECT_DIR$/src/phpunit.xml" scope="XML" use_alternative_configuration_file="true" />

--- a/.idea/workspace.xml
+++ b/.idea/workspace.xml
@@ -5,9 +5,10 @@
   </component>
   <component name="ChangeListManager">
     <list default="true" id="6952a861-17ec-40ad-b866-c564752c14a8" name="変更" comment="fix: test-environment-fix">
-      <change afterPath="$PROJECT_DIR$/src/app/User/Presentation/PresentationTest/Controller/UserController_updateTest.php" afterDir="false" />
+      <change afterPath="$PROJECT_DIR$/src/app/User/Domain/DomainTest/UserLoginEntityFactoryTest.php" afterDir="false" />
+      <change afterPath="$PROJECT_DIR$/src/app/User/Domain/Factory/UserLoginEntityFactory.php" afterDir="false" />
+      <change afterPath="$PROJECT_DIR$/src/app/User/Domain/ValueObject/AuthToken.php" afterDir="false" />
       <change beforePath="$PROJECT_DIR$/.idea/workspace.xml" beforeDir="false" afterPath="$PROJECT_DIR$/.idea/workspace.xml" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/src/app/User/Presentation/Controller/UserController.php" beforeDir="false" afterPath="$PROJECT_DIR$/src/app/User/Presentation/Controller/UserController.php" afterDir="false" />
     </list>
     <option name="SHOW_DIALOG" value="false" />
     <option name="HIGHLIGHT_CONFLICTS" value="true" />
@@ -162,7 +163,7 @@
     "PHPUnit.メイン.executor": "Run",
     "RunOnceActivity.ShowReadmeOnStart": "true",
     "RunOnceActivity.git.unshallow": "true",
-    "git-widget-placeholder": "feature/edit-user-controller",
+    "git-widget-placeholder": "feature/user-login-domain-valueobject",
     "node.js.detected.package.eslint": "true",
     "node.js.selected.package.eslint": "(autodetect)",
     "nodejs_package_manager_path": "npm",

--- a/.idea/workspace.xml
+++ b/.idea/workspace.xml
@@ -5,7 +5,6 @@
   </component>
   <component name="ChangeListManager">
     <list default="true" id="6952a861-17ec-40ad-b866-c564752c14a8" name="変更" comment="fix: test-environment-fix">
-      <change afterPath="$PROJECT_DIR$/src/app/User/Domain/Service/AuthServiceInterface.php" afterDir="false" />
       <change beforePath="$PROJECT_DIR$/.idea/workspace.xml" beforeDir="false" afterPath="$PROJECT_DIR$/.idea/workspace.xml" afterDir="false" />
     </list>
     <option name="SHOW_DIALOG" value="false" />
@@ -161,7 +160,7 @@
     "PHPUnit.メイン.executor": "Run",
     "RunOnceActivity.ShowReadmeOnStart": "true",
     "RunOnceActivity.git.unshallow": "true",
-    "git-widget-placeholder": "feature/user-login-authservice-interface",
+    "git-widget-placeholder": "feature/user-login-domain",
     "node.js.detected.package.eslint": "true",
     "node.js.selected.package.eslint": "(autodetect)",
     "nodejs_package_manager_path": "npm",

--- a/src/app/User/Domain/DomainTest/UserLoginEntityFactoryTest.php
+++ b/src/app/User/Domain/DomainTest/UserLoginEntityFactoryTest.php
@@ -1,0 +1,82 @@
+<?php
+
+namespace App\User\Domain\Factory;
+
+use Tests\TestCase;
+use Mockery;
+use App\User\Domain\RepositoryInterface\PasswordHasherInterface;
+use App\User\Domain\Factory\UserLoginEntityFactory;
+use App\User\Domain\Entity\UserEntity;
+use App\User\Domain\ValueObject\Email;
+
+class UserLoginEntityFactoryTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+    }
+
+    protected function tearDown(): void
+    {
+        parent::tearDown();
+    }
+
+    private function mockPasswordHasher(): PasswordHasherInterface
+    {
+        $hasher = Mockery::mock(PasswordHasherInterface::class);
+
+        $hasher
+            ->shouldReceive('hash')
+            ->andReturn($this->arrayData()['password']);
+
+        return $hasher;
+    }
+
+    private function arrayData(): array
+    {
+        return [
+            'first_name' => '',
+            'last_name' => '',
+            'email' => 'argentina-10@test.com',
+            'password' => 'test1234',
+            'bio' => null,
+            'location' => null,
+            'skills' => [],
+            'profile_image' => null,
+        ];
+    }
+
+    /**
+     * @test
+     * @testdox UserLoginEntityFactory should build a UserEntity with correct data
+     */
+    public function test1(): void
+    {
+        $result = UserLoginEntityFactory::build(
+            $this->arrayData(),
+            $this->mockPasswordHasher()
+        );
+
+        $this->assertInstanceOf(UserEntity::class, $result);
+    }
+
+    /**
+     * @test
+     * @testdox UserLoginEntityFactory should handle missing optional fields
+     */
+    public function test2(): void
+    {
+        $result = UserLoginEntityFactory::build(
+            $this->arrayData(),
+            $this->mockPasswordHasher()
+        );
+
+        $this->assertEquals($this->arrayData()['first_name'], $result->getFirstName());
+        $this->assertEquals($this->arrayData()['last_name'], $result->getLastName());
+        $this->assertEquals(new Email($this->arrayData()['email']), $result->getEmail());
+        $this->assertEquals($this->arrayData()['bio'], $result->getBio());
+        $this->assertEquals($this->arrayData()['location'], $result->getLocation());
+        $this->assertEquals($this->arrayData()['skills'], $result->getSkills());
+        $this->assertEquals($this->arrayData()['profile_image'], $result->getProfileImage());
+    }
+}

--- a/src/app/User/Domain/Factory/UserLoginEntityFactory.php
+++ b/src/app/User/Domain/Factory/UserLoginEntityFactory.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace App\User\Domain\Factory;
+
+use App\User\Domain\ValueObject\Email;
+use App\User\Domain\ValueObject\Password;
+use App\User\Domain\Entity\UserEntity;
+use App\User\Domain\RepositoryInterface\PasswordHasherInterface;
+
+class UserLoginEntityFactory
+{
+    public static function build(
+        array $request,
+        PasswordHasherInterface $hasher
+    ): UserEntity
+    {
+        return new UserEntity(
+            firstName: '',
+            lastName: '',
+            email: new Email($request['email']),
+            password: Password::fromPlainText(
+                $request['password'],
+                $hasher
+            ),
+            bio: null,
+            location: null,
+            skills: [],
+            profileImage: null,
+        );
+    }
+}

--- a/src/app/User/Domain/Service/AuthServiceInterface.php
+++ b/src/app/User/Domain/Service/AuthServiceInterface.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace App\User\Domain\Service;
+
+use App\User\Domain\Entity\UserEntity;
+use App\User\Domain\ValueObject\Email;
+use App\User\Domain\ValueObject\Password;
+
+interface AuthServiceInterface
+{
+    public function attemptLogin(
+        Email $email,
+        Password $password
+    )
+    : ?UserEntity;
+}

--- a/src/app/User/Domain/Service/GenerateTokenInterface.php
+++ b/src/app/User/Domain/Service/GenerateTokenInterface.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace App\User\Domain\Service;
+
+use App\User\Domain\Entity\UserEntity;
+use App\User\Domain\ValueObject\AuthToken;
+
+interface GenerateTokenInterface
+{
+    /**
+     *
+     * @param UserEntity $user
+     * @return AuthToken
+     */
+    public function issue(UserEntity $user): AuthToken;
+}

--- a/src/app/User/Domain/ValueObject/AuthToken.php
+++ b/src/app/User/Domain/ValueObject/AuthToken.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace App\User\Domain\ValueObject;
+
+use InvalidArgumentException;
+
+final class AuthToken
+{
+    public function __construct(
+        private string $value,
+        private string $type = 'Bearer'
+    ) {}
+
+    public function getValue(): string
+    {
+        return $this->value;
+    }
+
+    public function getType(): string
+    {
+        return $this->type;
+    }
+
+    public function __toString(): string
+    {
+        return "{$this->type} {$this->value}";
+    }
+
+}


### PR DESCRIPTION
### Description

Defined `GenerateTokenInterface` in the User Login Domain layer to represent the contract for issuing authentication tokens for authenticated users.  
This interface abstracts the token generation logic (e.g., JWT issuance) away from domain-level logic and prepares the application for pluggable infrastructure-level implementations.

### Changes

- Created `GenerateTokenInterface` under `App\User\Domain\Service`
- Declared method `issue(UserEntity $user): AuthToken`
- Used `AuthToken` value object to wrap issued token
- Maintained strict typing and single responsibility principle