### PR TITLE
Merge Presentation Layer into Login API Endpoint

### DIFF
--- a/.idea/workspace.xml
+++ b/.idea/workspace.xml
@@ -5,9 +5,7 @@
   </component>
   <component name="ChangeListManager">
     <list default="true" id="6952a861-17ec-40ad-b866-c564752c14a8" name="変更" comment="fix: test-environment-fix">
-      <change afterPath="$PROJECT_DIR$/src/app/User/Presentation/PresentationTest/Controller/UserController_loginTest.php" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/.idea/workspace.xml" beforeDir="false" afterPath="$PROJECT_DIR$/.idea/workspace.xml" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/src/app/User/Presentation/Controller/UserController.php" beforeDir="false" afterPath="$PROJECT_DIR$/src/app/User/Presentation/Controller/UserController.php" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/app/User/Presentation/PresentationTest/Controller/UserController_loginTest.php" beforeDir="false" afterPath="$PROJECT_DIR$/src/app/User/Presentation/PresentationTest/Controller/UserController_loginTest.php" afterDir="false" />
     </list>
     <option name="SHOW_DIALOG" value="false" />
     <option name="HIGHLIGHT_CONFLICTS" value="true" />
@@ -163,7 +161,7 @@
     "PHPUnit.メイン.executor": "Run",
     "RunOnceActivity.ShowReadmeOnStart": "true",
     "RunOnceActivity.git.unshallow": "true",
-    "git-widget-placeholder": "feature/user-login-presentation-controller",
+    "git-widget-placeholder": "feature/user-login-presentation",
     "node.js.detected.package.eslint": "true",
     "node.js.selected.package.eslint": "(autodetect)",
     "nodejs_package_manager_path": "npm",

--- a/.idea/workspace.xml
+++ b/.idea/workspace.xml
@@ -5,9 +5,9 @@
   </component>
   <component name="ChangeListManager">
     <list default="true" id="6952a861-17ec-40ad-b866-c564752c14a8" name="変更" comment="fix: test-environment-fix">
-      <change afterPath="$PROJECT_DIR$/src/app/User/Application/ApplicationTest/LoginUserUseCaseTest.php" afterDir="false" />
-      <change afterPath="$PROJECT_DIR$/src/app/User/Application/UseCase/LoginUserUseCase.php" afterDir="false" />
+      <change afterPath="$PROJECT_DIR$/src/app/User/Presentation/PresentationTest/Controller/UserController_loginTest.php" afterDir="false" />
       <change beforePath="$PROJECT_DIR$/.idea/workspace.xml" beforeDir="false" afterPath="$PROJECT_DIR$/.idea/workspace.xml" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/app/User/Presentation/Controller/UserController.php" beforeDir="false" afterPath="$PROJECT_DIR$/src/app/User/Presentation/Controller/UserController.php" afterDir="false" />
     </list>
     <option name="SHOW_DIALOG" value="false" />
     <option name="HIGHLIGHT_CONFLICTS" value="true" />
@@ -163,7 +163,7 @@
     "PHPUnit.メイン.executor": "Run",
     "RunOnceActivity.ShowReadmeOnStart": "true",
     "RunOnceActivity.git.unshallow": "true",
-    "git-widget-placeholder": "feature/user-login-application-usecase",
+    "git-widget-placeholder": "feature/user-login-presentation-controller",
     "node.js.detected.package.eslint": "true",
     "node.js.selected.package.eslint": "(autodetect)",
     "nodejs_package_manager_path": "npm",

--- a/src/app/User/Presentation/Controller/UserController.php
+++ b/src/app/User/Presentation/Controller/UserController.php
@@ -4,6 +4,7 @@ namespace App\User\Presentation\Controller;
 
 use App\Http\Controllers\Controller;
 use App\User\Application\Factory\RegisterUserCommandFactory;
+use App\User\Application\UseCase\LoginUserUseCase;
 use App\User\Application\UseCase\ShowUserUseCase;
 use App\User\Presentation\ViewModel\Factory\RegisterUserViewModelFactory;
 use App\User\Presentation\ViewModel\ShowUserViewModel;
@@ -83,6 +84,37 @@ class UserController extends Controller
             ], 200);
         } catch (Exception $e) {
             DB::connection('mysql')->rollBack();
+
+            return response()->json([
+                'status' => 'error',
+                'message' => $e->getMessage(),
+            ], 500);
+        }
+    }
+
+    public function login(
+        Request $request,
+        LoginUserUseCase $useCase
+    ): JsonResponse
+    {
+        try {
+            $requestEmail = $request->input('email');
+            $requestPassword = $request->input('password');
+
+            $dto = $useCase->handle(
+                $requestEmail,
+                $requestPassword
+            );
+
+            return response()->json([
+                'status' => 'success',
+                'data' => [
+                    'token' => $dto->getToken(),
+                    'user' => $dto->toArray()
+                ],
+            ], 200);
+
+        } catch (Exception $e) {
 
             return response()->json([
                 'status' => 'error',

--- a/src/app/User/Presentation/PresentationTest/Controller/UserController_loginTest.php
+++ b/src/app/User/Presentation/PresentationTest/Controller/UserController_loginTest.php
@@ -76,7 +76,6 @@ class UserController_loginTest extends TestCase
         $request
             ->shouldReceive('input')
             ->with('password')
-            ->with('password')
             ->andReturn($this->arrayRequestData()['password']);
 
         return $request;

--- a/src/app/User/Presentation/PresentationTest/Controller/UserController_loginTest.php
+++ b/src/app/User/Presentation/PresentationTest/Controller/UserController_loginTest.php
@@ -1,0 +1,106 @@
+<?php
+
+namespace App\User\Presentation\PresentationTest\Controller;
+
+use App\User\Domain\ValueObject\AuthToken;
+use Tests\TestCase;
+use App\User\Presentation\Controller\UserController;
+use Illuminate\Http\Request;
+use App\User\Application\UseCase\LoginUserUseCase;
+use App\User\Application\Dto\LoginUserDto;
+use Mockery;
+
+class UserController_loginTest extends TestCase
+{
+    const MOCK_TOKEN = 'test-token';
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->controller = new UserController();
+        $this->token = new AuthToken(self::MOCK_TOKEN);
+    }
+
+    protected function tearDown(): void
+    {
+        parent::tearDown();
+    }
+
+    private function mockUseCase(): LoginUserUseCase
+    {
+        $useCase = Mockery::mock(LoginUserUseCase::class);
+
+        $useCase
+            ->shouldReceive('handle')
+            ->with(
+                $this->arrayRequestData()['email'],
+                $this->arrayRequestData()['password']
+            )
+            ->andReturn($this->mockDto());
+
+
+        return $useCase;
+    }
+
+    private function mockDto(): LoginUserDto
+    {
+        $dto = Mockery::mock(LoginUserDto::class);
+
+        $dto
+            ->shouldReceive('getEmail')
+            ->andReturn($this->arrayRequestData()['email']);
+
+        $dto
+            ->shouldReceive('getPassword')
+            ->andReturn($this->arrayRequestData()['password']);
+
+        $dto
+            ->shouldReceive('getToken')
+            ->andReturn(new AuthToken(self::MOCK_TOKEN));
+
+        $dto
+            ->shouldReceive('toArray')
+            ->andReturn($this->arrayRequestData() + ['token' => self::MOCK_TOKEN]);
+
+        return $dto;
+    }
+
+    private function mockRequest(): Request
+    {
+        $request = Mockery::mock(Request::class);
+
+        $request
+            ->shouldReceive('input')
+            ->with('email')
+            ->andReturn($this->arrayRequestData()['email']);
+
+        $request
+            ->shouldReceive('input')
+            ->with('password')
+            ->with('password')
+            ->andReturn($this->arrayRequestData()['password']);
+
+        return $request;
+    }
+
+    private function arrayRequestData(): array
+    {
+        return [
+            'email' => 'liverpool-8@test.com',
+            'password' => 'password1234',
+        ];
+    }
+
+    /**
+     * @test
+     * @testdox UserController_loginTest_successfully
+     */
+    public function test1(): void
+    {
+        $response = $this->controller->login(
+            $this->mockRequest(),
+            $this->mockUseCase()
+        );
+
+        $this->assertEquals(200, $response->getStatusCode());
+    }
+}


### PR DESCRIPTION
### Description

This pull request connects the Presentation layer with the existing Application and Domain layers to enable full end-to-end handling of the user login API.

#### Changes Summary:

- Integrated `UserController@login()` with `LoginUserUseCase`
- Parsed `email` and `password` from the HTTP request
- Returned JSON response with:
  - `status: success | error`
  - `data`: includes user info and JWT token
  - `message`: error reason if login fails
- Improved exception handling and output consistency
- Presentation test (`UserController_loginTest`) verifies controller behaviour with mocks
