### PR TITLE
Add User Logout capability to Domain Layer via AuthServiceInterface

### DIFF
--- a/.idea/workspace.xml
+++ b/.idea/workspace.xml
@@ -5,14 +5,8 @@
   </component>
   <component name="ChangeListManager">
     <list default="true" id="6952a861-17ec-40ad-b866-c564752c14a8" name="変更" comment="fix: test-environment-fix">
-      <change afterPath="$PROJECT_DIR$/src/app/User/Tests/User_loginTest.php" afterDir="false" />
       <change beforePath="$PROJECT_DIR$/.idea/workspace.xml" beforeDir="false" afterPath="$PROJECT_DIR$/.idea/workspace.xml" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/src/app/Providers/AppServiceProvider.php" beforeDir="false" afterPath="$PROJECT_DIR$/src/app/Providers/AppServiceProvider.php" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/src/app/User/Domain/ValueObject/Password.php" beforeDir="false" afterPath="$PROJECT_DIR$/src/app/User/Domain/ValueObject/Password.php" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/src/app/User/Infrastructure/Service/BcryptPasswordHasher.php" beforeDir="false" afterPath="$PROJECT_DIR$/src/app/User/Infrastructure/Service/BcryptPasswordHasher.php" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/src/app/User/Infrastructure/Service/JwtAuthService.php" beforeDir="false" afterPath="$PROJECT_DIR$/src/app/User/Infrastructure/Service/JwtAuthService.php" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/src/config/auth.php" beforeDir="false" afterPath="$PROJECT_DIR$/src/config/auth.php" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/src/routes/api.php" beforeDir="false" afterPath="$PROJECT_DIR$/src/routes/api.php" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/app/User/Domain/Service/AuthServiceInterface.php" beforeDir="false" afterPath="$PROJECT_DIR$/src/app/User/Domain/Service/AuthServiceInterface.php" afterDir="false" />
     </list>
     <option name="SHOW_DIALOG" value="false" />
     <option name="HIGHLIGHT_CONFLICTS" value="true" />
@@ -168,7 +162,7 @@
     "PHPUnit.メイン.executor": "Run",
     "RunOnceActivity.ShowReadmeOnStart": "true",
     "RunOnceActivity.git.unshallow": "true",
-    "git-widget-placeholder": "feature/user-login-test",
+    "git-widget-placeholder": "feature/user-logout-domain-authservice",
     "node.js.detected.package.eslint": "true",
     "node.js.selected.package.eslint": "(autodetect)",
     "nodejs_package_manager_path": "npm",

--- a/src/app/User/Domain/Service/AuthServiceInterface.php
+++ b/src/app/User/Domain/Service/AuthServiceInterface.php
@@ -13,4 +13,8 @@ interface AuthServiceInterface
         Password $password
     )
     : ?UserEntity;
+
+    public function attemptLogout(
+        UserEntity $user
+    ): void;
 }


### PR DESCRIPTION
### Description

This pull request formally introduces logout support within the Domain Layer as part of the User authentication lifecycle. The key changes involve expanding the `AuthServiceInterface` to include an `attemptLogout(UserEntity $user): void` method, thereby preparing the foundation for application-level integration of logout functionality.

#### Summary of changes:

- Added `attemptLogout()` method to `AuthServiceInterface` to express logout intention in the domain.
- Maintained contract simplicity: no return value, enforcing void for separation of concerns.
- Logout is designed as a command rather than a query, aligning with behavioural DDD practices.
- No token state management included (to remain consistent with stateless JWT design).

This enhancement ensures the domain logic explicitly supports logout use cases, which:
- Improves clarity in business requirements representation.
- Enables application logic to remain thin and focused.
- Paves the way for consistent future expansion (e.g., token revocation, audit logging, etc.).