### PR TITLE
Add placeholder logout implementation to AuthServiceInterface

### DIFF
--- a/.idea/workspace.xml
+++ b/.idea/workspace.xml
@@ -6,7 +6,7 @@
   <component name="ChangeListManager">
     <list default="true" id="6952a861-17ec-40ad-b866-c564752c14a8" name="変更" comment="fix: test-environment-fix">
       <change beforePath="$PROJECT_DIR$/.idea/workspace.xml" beforeDir="false" afterPath="$PROJECT_DIR$/.idea/workspace.xml" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/src/app/User/Domain/Service/AuthServiceInterface.php" beforeDir="false" afterPath="$PROJECT_DIR$/src/app/User/Domain/Service/AuthServiceInterface.php" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/app/User/Infrastructure/Service/JwtAuthService.php" beforeDir="false" afterPath="$PROJECT_DIR$/src/app/User/Infrastructure/Service/JwtAuthService.php" afterDir="false" />
     </list>
     <option name="SHOW_DIALOG" value="false" />
     <option name="HIGHLIGHT_CONFLICTS" value="true" />
@@ -162,7 +162,7 @@
     "PHPUnit.メイン.executor": "Run",
     "RunOnceActivity.ShowReadmeOnStart": "true",
     "RunOnceActivity.git.unshallow": "true",
-    "git-widget-placeholder": "feature/user-logout-domain-authservice",
+    "git-widget-placeholder": "feature/user-logout-infra-authservice",
     "node.js.detected.package.eslint": "true",
     "node.js.selected.package.eslint": "(autodetect)",
     "nodejs_package_manager_path": "npm",

--- a/src/app/User/Infrastructure/Service/JwtAuthService.php
+++ b/src/app/User/Infrastructure/Service/JwtAuthService.php
@@ -41,4 +41,12 @@ class JwtAuthService implements AuthServiceInterface
 
         return $user;
     }
+
+    public function attemptLogout(UserEntity $user): void
+    {
+        // In a JWT-based system, logout is typically handled by removing the token from the client side.
+        // However, if you want to implement server-side token invalidation, you can do so here.
+        // For example, you could maintain a blacklist of tokens or change the user's password to invalidate existing tokens.
+        // This is a placeholder for such logic.
+    }
 }


### PR DESCRIPTION
### description
This pull request introduces a no-op implementation for the `attemptLogout(UserEntity $user): void` method in the `JwtAuthService` class. Since we are utilising a stateless JWT-based authentication system, logout is typically handled on the client side by deleting the token.

However, this method serves as a structural placeholder and future extension point for server-side token invalidation strategies (e.g., token blacklisting, revoking via password rotation, etc).

Changes:
- Implemented `attemptLogout()` in `JwtAuthService` as a placeholder.
- Added inline documentation explaining its purpose and potential use cases.