### PR TITLE
Implement `LogoutUserUseCase` to encapsulate user logout logic via Domain service

### DIFF
--- a/.idea/workspace.xml
+++ b/.idea/workspace.xml
@@ -5,8 +5,9 @@
   </component>
   <component name="ChangeListManager">
     <list default="true" id="6952a861-17ec-40ad-b866-c564752c14a8" name="変更" comment="fix: test-environment-fix">
+      <change afterPath="$PROJECT_DIR$/src/app/User/Application/ApplicationTest/LogoutUserUseCaseTest.php" afterDir="false" />
+      <change afterPath="$PROJECT_DIR$/src/app/User/Application/UseCase/LogoutUserUseCase.php" afterDir="false" />
       <change beforePath="$PROJECT_DIR$/.idea/workspace.xml" beforeDir="false" afterPath="$PROJECT_DIR$/.idea/workspace.xml" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/src/app/User/Infrastructure/Service/JwtAuthService.php" beforeDir="false" afterPath="$PROJECT_DIR$/src/app/User/Infrastructure/Service/JwtAuthService.php" afterDir="false" />
     </list>
     <option name="SHOW_DIALOG" value="false" />
     <option name="HIGHLIGHT_CONFLICTS" value="true" />
@@ -162,7 +163,7 @@
     "PHPUnit.メイン.executor": "Run",
     "RunOnceActivity.ShowReadmeOnStart": "true",
     "RunOnceActivity.git.unshallow": "true",
-    "git-widget-placeholder": "feature/user-logout-infra-authservice",
+    "git-widget-placeholder": "feature/user-logout-application-usecase",
     "node.js.detected.package.eslint": "true",
     "node.js.selected.package.eslint": "(autodetect)",
     "nodejs_package_manager_path": "npm",

--- a/src/app/User/Application/ApplicationTest/LogoutUserUseCaseTest.php
+++ b/src/app/User/Application/ApplicationTest/LogoutUserUseCaseTest.php
@@ -1,0 +1,128 @@
+<?php
+
+namespace App\User\Application\ApplicationTest;
+
+use App\Common\Domain\UserId;
+use Tests\TestCase;
+use App\User\Application\UseCase\LogoutUserUseCase;
+use App\User\Domain\Service\AuthServiceInterface;
+use App\User\Domain\Entity\UserEntity;
+use Mockery;
+use App\User\Domain\Factory\UserEntityFactory;
+use App\User\Domain\RepositoryInterface\PasswordHasherInterface;
+
+class LogoutUserUseCaseTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+    }
+
+    protected function tearDown(): void
+    {
+        parent::tearDown();
+    }
+
+    public function test_succeeded(): void
+    {
+        $authService = $this->mockAuthService();
+        $useCase = new LogoutUserUseCase($authService);
+
+        $useCase->handle($this->mockEntity());
+
+        $this->assertInstanceOf(LogoutUserUseCase::class, $useCase);
+    }
+
+    private function mockEntity(): UserEntity
+    {
+        $factory = Mockery::mock(
+            'alias' . UserEntityFactory::class
+        );
+
+        $entity = Mockery::mock(UserEntity::class);
+
+        $factory
+            ->shouldReceive('build')
+            ->with($this->arrayData())
+            ->with($this->mockPasswordHasher())
+            ->andReturn($entity);
+
+        $entity
+            ->shouldReceive('getId')
+            ->andReturn(new UserId($this->arrayData()['id']));
+
+        $entity
+            ->shouldReceive('getEmail')
+            ->andReturn($this->arrayData()['email']);
+
+        $entity
+            ->shouldReceive('getPassword')
+            ->andReturn($this->arrayData()['password']);
+
+        $entity
+            ->shouldReceive('getFirstName')
+            ->andReturn($this->arrayData()['first_name']);
+
+        $entity
+            ->shouldReceive('getLastName')
+            ->andReturn($this->arrayData()['last_name']);
+
+        $entity
+            ->shouldReceive('getBio')
+            ->andReturn($this->arrayData()['bio']);
+
+        $entity
+            ->shouldReceive('getLocation')
+            ->andReturn($this->arrayData()['location']);
+
+        $entity
+            ->shouldReceive('getSkills')
+            ->andReturn($this->arrayData()['skills']);
+
+        $entity
+            ->shouldReceive('getProfileImage')
+            ->andReturn($this->arrayData()['profile_image']);
+
+        return $entity;
+    }
+
+    private function mockPasswordHasher(): PasswordHasherInterface
+    {
+        $hasher = Mockery::mock(PasswordHasherInterface::class);
+
+        $hasher
+            ->shouldReceive('hash')
+            ->andReturn($this->arrayData()['password']);
+
+        return $hasher;
+    }
+
+    private function arrayData(): array
+    {
+        return [
+            'id' => 1,
+            'first_name' => 'Sergio',
+            'last_name' => 'Ramos',
+            'email' => 'real-madrid4@test.com',
+            'password' => 'el-capitán-1234',
+            'bio' => 'Real Madrid player',
+            'location' => 'Madrid',
+            'skills' => ['Football', 'Leadership'],
+            'profile_image' => 'https://example.com/sergio.jpg',
+        ];
+    }
+
+    private function mockAuthService(): AuthServiceInterface
+    {
+        $authService = Mockery::mock(
+            AuthServiceInterface::class
+        );
+
+        $authService
+            ->shouldReceive('attemptLogout')
+            ->with(Mockery::type(UserEntity::class))
+            ->andReturn(true);
+
+        return $authService;
+    }
+}

--- a/src/app/User/Application/UseCase/LogoutUserUseCase.php
+++ b/src/app/User/Application/UseCase/LogoutUserUseCase.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace App\User\Application\UseCase;
+
+use App\User\Domain\Service\AuthServiceInterface;
+use App\User\Domain\Entity\UserEntity;
+
+class LogoutUserUseCase
+{
+    public function __construct(
+        private readonly AuthServiceInterface $authService,
+    ) {
+    }
+
+    public function handle(
+        UserEntity $user
+    ): void
+    {
+        $this->authService->attemptLogout($user);
+    }
+}


### PR DESCRIPTION
### description

This pull request introduces the `LogoutUserUseCase` within the Application layer.  
Its purpose is to delegate logout behaviour to the `AuthServiceInterface` defined in the Domain layer, maintaining a clean separation of concerns and enforcing consistency in the logout process.

#### Changes included:
- Added `LogoutUserUseCase` class under `App\User\Application\UseCase`
- Injected `AuthServiceInterface` via constructor
- Implemented `handle(UserEntity $user)` method which calls `attemptLogout`

This design keeps Application layer logic simple and aligned with DDD principles.