### PR TITLE
implement user logout controller logic with DDD-aligned use case

### DIFF
--- a/.idea/workspace.xml
+++ b/.idea/workspace.xml
@@ -5,8 +5,9 @@
   </component>
   <component name="ChangeListManager">
     <list default="true" id="6952a861-17ec-40ad-b866-c564752c14a8" name="変更" comment="fix: test-environment-fix">
+      <change afterPath="$PROJECT_DIR$/src/app/User/Presentation/PresentationTest/Controller/UserController_logoutTest.php" afterDir="false" />
       <change beforePath="$PROJECT_DIR$/.idea/workspace.xml" beforeDir="false" afterPath="$PROJECT_DIR$/.idea/workspace.xml" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/src/app/User/Application/UseCase/LogoutUserUseCase.php" beforeDir="false" afterPath="$PROJECT_DIR$/src/app/User/Application/UseCase/LogoutUserUseCase.php" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/app/User/Presentation/Controller/UserController.php" beforeDir="false" afterPath="$PROJECT_DIR$/src/app/User/Presentation/Controller/UserController.php" afterDir="false" />
     </list>
     <option name="SHOW_DIALOG" value="false" />
     <option name="HIGHLIGHT_CONFLICTS" value="true" />
@@ -162,7 +163,7 @@
     "PHPUnit.メイン.executor": "Run",
     "RunOnceActivity.ShowReadmeOnStart": "true",
     "RunOnceActivity.git.unshallow": "true",
-    "git-widget-placeholder": "feature/fix-user-logout-application",
+    "git-widget-placeholder": "feature/user-logout-presentation-controller",
     "node.js.detected.package.eslint": "true",
     "node.js.selected.package.eslint": "(autodetect)",
     "nodejs_package_manager_path": "npm",

--- a/.idea/workspace.xml
+++ b/.idea/workspace.xml
@@ -5,9 +5,8 @@
   </component>
   <component name="ChangeListManager">
     <list default="true" id="6952a861-17ec-40ad-b866-c564752c14a8" name="変更" comment="fix: test-environment-fix">
-      <change afterPath="$PROJECT_DIR$/src/app/User/Application/ApplicationTest/LogoutUserUseCaseTest.php" afterDir="false" />
-      <change afterPath="$PROJECT_DIR$/src/app/User/Application/UseCase/LogoutUserUseCase.php" afterDir="false" />
       <change beforePath="$PROJECT_DIR$/.idea/workspace.xml" beforeDir="false" afterPath="$PROJECT_DIR$/.idea/workspace.xml" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/app/User/Application/UseCase/LogoutUserUseCase.php" beforeDir="false" afterPath="$PROJECT_DIR$/src/app/User/Application/UseCase/LogoutUserUseCase.php" afterDir="false" />
     </list>
     <option name="SHOW_DIALOG" value="false" />
     <option name="HIGHLIGHT_CONFLICTS" value="true" />
@@ -163,7 +162,7 @@
     "PHPUnit.メイン.executor": "Run",
     "RunOnceActivity.ShowReadmeOnStart": "true",
     "RunOnceActivity.git.unshallow": "true",
-    "git-widget-placeholder": "feature/user-logout-application-usecase",
+    "git-widget-placeholder": "feature/fix-user-logout-application",
     "node.js.detected.package.eslint": "true",
     "node.js.selected.package.eslint": "(autodetect)",
     "nodejs_package_manager_path": "npm",

--- a/src/app/User/Application/ApplicationTest/LogoutUserUseCaseTest.php
+++ b/src/app/User/Application/ApplicationTest/LogoutUserUseCaseTest.php
@@ -3,6 +3,8 @@
 namespace App\User\Application\ApplicationTest;
 
 use App\Common\Domain\UserId;
+use App\User\Domain\RepositoryInterface\UserRepositoryInterface;
+use App\User\Infrastructure\Repository\UserRepository;
 use Tests\TestCase;
 use App\User\Application\UseCase\LogoutUserUseCase;
 use App\User\Domain\Service\AuthServiceInterface;
@@ -26,9 +28,13 @@ class LogoutUserUseCaseTest extends TestCase
     public function test_succeeded(): void
     {
         $authService = $this->mockAuthService();
-        $useCase = new LogoutUserUseCase($authService);
+        $repository = $this->mockRepository();
+        $useCase = new LogoutUserUseCase(
+            $authService,
+            $repository
+        );
 
-        $useCase->handle($this->mockEntity());
+        $useCase->handle($this->arrayData()['id']);
 
         $this->assertInstanceOf(LogoutUserUseCase::class, $useCase);
     }
@@ -83,6 +89,20 @@ class LogoutUserUseCaseTest extends TestCase
             ->andReturn($this->arrayData()['profile_image']);
 
         return $entity;
+    }
+
+    private function mockRepository(): UserRepositoryInterface
+    {
+        $interface = Mockery::mock(
+            UserRepositoryInterface::class
+        );
+
+        $interface
+            ->shouldReceive('findById')
+            ->with(Mockery::type(UserId::class))
+            ->andReturn($this->mockEntity());
+
+        return $interface;
     }
 
     private function mockPasswordHasher(): PasswordHasherInterface

--- a/src/app/User/Application/UseCase/LogoutUserUseCase.php
+++ b/src/app/User/Application/UseCase/LogoutUserUseCase.php
@@ -2,20 +2,25 @@
 
 namespace App\User\Application\UseCase;
 
+use App\User\Domain\RepositoryInterface\UserRepositoryInterface;
 use App\User\Domain\Service\AuthServiceInterface;
 use App\User\Domain\Entity\UserEntity;
+use App\Common\Domain\UserId;
 
 class LogoutUserUseCase
 {
     public function __construct(
         private readonly AuthServiceInterface $authService,
+        private readonly UserRepositoryInterface $repositoryInterface
     ) {
     }
 
     public function handle(
-        UserEntity $user
+        int $userId
     ): void
     {
-        $this->authService->attemptLogout($user);
+        $targetUser = $this->repositoryInterface->findById(new UserId($userId));
+
+        $this->authService->attemptLogout($targetUser);
     }
 }

--- a/src/app/User/Presentation/Controller/UserController.php
+++ b/src/app/User/Presentation/Controller/UserController.php
@@ -14,7 +14,9 @@ use App\User\Application\UseCase\RegisterUserUsecase;
 use App\User\Application\UseCase\UpdateUseCase;
 use App\User\Application\UseCommand\UpdateUserCommand;
 use App\User\Presentation\ViewModel\UpdateUserViewModel;
+use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\DB;
+use App\User\Application\UseCase\LogoutUserUseCase;
 use Exception;
 
 class UserController extends Controller
@@ -120,6 +122,24 @@ class UserController extends Controller
                 'status' => 'error',
                 'message' => $e->getMessage(),
             ], 500);
+        }
+    }
+
+    public function logout(
+        LogoutUserUseCase $useCase
+    ): void
+    {
+        try {
+            $authUser = Auth::user();
+
+            if (!$authUser) {
+                throw new Exception('User not authenticated');
+            }
+
+            $useCase->handle($authUser->id);
+
+        } catch (Exception $e) {
+            throw new Exception('Logout failed: ' . $e->getMessage());
         }
     }
 }

--- a/src/app/User/Presentation/PresentationTest/Controller/UserController_logoutTest.php
+++ b/src/app/User/Presentation/PresentationTest/Controller/UserController_logoutTest.php
@@ -1,0 +1,130 @@
+<?php
+
+namespace App\User\Presentation\PresentationTest\Controller;
+
+use App\User\Application\UseCase\LogoutUserUseCase;
+use App\User\Domain\RepositoryInterface\PasswordHasherInterface;
+use App\User\Domain\RepositoryInterface\UserRepositoryInterface;
+use App\User\Domain\Service\AuthServiceInterface;
+use Illuminate\Support\Facades\Auth;
+use Illuminate\Support\Facades\DB;
+use Tests\TestCase;
+use App\User\Presentation\Controller\UserController;
+use Mockery;
+use App\User\Domain\Entity\UserEntity;
+use App\User\Domain\Factory\UserEntityFactory;
+use App\Common\Domain\UserId;
+use App\Models\User;
+
+class UserController_logoutTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->refresh();
+        $this->controller = new UserController();
+    }
+
+    protected function tearDown(): void
+    {
+        $this->refresh();
+        parent::tearDown();
+    }
+
+    private function refresh(): void
+    {
+        if (env('APP_ENV') === 'testing') {
+            DB::connection('mysql')->statement('SET FOREIGN_KEY_CHECKS=0;');
+            User::truncate();
+            DB::connection('mysql')->statement('SET FOREIGN_KEY_CHECKS=1;');
+        }
+    }
+
+    private function mockUseCase(): LogoutUserUseCase
+    {
+        return new LogoutUserUseCase(
+            $this->mockAuthService(),
+            $this->mockRepository()
+        );
+    }
+
+    private function mockAuthService(): AuthServiceInterface
+    {
+        $authService = Mockery::mock(AuthServiceInterface::class);
+
+        $authService
+            ->shouldReceive('attemptLogout')
+            ->with(Mockery::type(UserEntity::class))
+            ->andReturnNull();
+
+        return $authService;
+    }
+
+    private function mockRepository(): UserRepositoryInterface
+    {
+        $repository = Mockery::mock(UserRepositoryInterface::class);
+
+        $repository
+            ->shouldReceive('findById')
+            ->with(Mockery::type(UserId::class))
+            ->andReturn($this->mockEntity());
+
+        return $repository;
+    }
+
+    private function mockEntity(): UserEntity
+    {
+        $factory = Mockery::mock(
+            'alias:' . UserEntityFactory::class
+        );
+
+        $entity = Mockery::mock(UserEntity::class);
+
+        $factory
+            ->shouldReceive('build')
+            ->with($this->arrayData(), $this->mockPasswordHasher())
+            ->andReturn($entity);
+
+        $entity
+            ->shouldReceive('getId')
+            ->andReturn(new UserId(1));
+
+        return $entity;
+    }
+
+    private function arrayData(): array
+    {
+        return [
+            'first_name' => 'John',
+            'last_name' => 'Terry',
+            'email' => 'chelsea-26@test.com',
+            'password' => 'test1234',
+        ];
+    }
+
+    private function mockPasswordHasher(): PasswordHasherInterface
+    {
+        $hasher = Mockery::mock(PasswordHasherInterface::class);
+
+        $hasher
+            ->shouldReceive('hash')
+            ->with($this->arrayData()['password'])
+            ->andReturn($this->arrayData()['password']);
+
+        return $hasher;
+    }
+
+    public function test1(): void
+    {
+        $user = User::create($this->arrayData());
+
+        Auth::shouldReceive('user')
+            ->andReturn($user);
+
+        $useCase = $this->mockUseCase();
+
+        $this->controller->logout($useCase);
+
+        $this->assertTrue(true);
+    }
+}


### PR DESCRIPTION
### Description

This PR implements the `logout` method within the `UserController`. It is structured based on Domain-Driven Design (DDD) principles and does the following:

- Retrieves the authenticated user using Laravel's `Auth::user()`.
- Validates authentication presence.
- Passes the user ID to the `LogoutUserUseCase`.
- Handles and rethrows exceptions with context.