### PR TITLE
Add feature test for user logout via JWT authentication

### DIFF
--- a/.idea/workspace.xml
+++ b/.idea/workspace.xml
@@ -5,9 +5,12 @@
   </component>
   <component name="ChangeListManager">
     <list default="true" id="6952a861-17ec-40ad-b866-c564752c14a8" name="変更" comment="fix: test-environment-fix">
-      <change afterPath="$PROJECT_DIR$/src/app/User/Presentation/PresentationTest/Controller/UserController_logoutTest.php" afterDir="false" />
+      <change afterPath="$PROJECT_DIR$/src/app/User/Tests/User_LogoutTest.php" afterDir="false" />
       <change beforePath="$PROJECT_DIR$/.idea/workspace.xml" beforeDir="false" afterPath="$PROJECT_DIR$/.idea/workspace.xml" afterDir="false" />
       <change beforePath="$PROJECT_DIR$/src/app/User/Presentation/Controller/UserController.php" beforeDir="false" afterPath="$PROJECT_DIR$/src/app/User/Presentation/Controller/UserController.php" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/app/User/Tests/User_loginTest.php" beforeDir="false" afterPath="$PROJECT_DIR$/src/app/User/Tests/User_LoginTest.php" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/config/auth.php" beforeDir="false" afterPath="$PROJECT_DIR$/src/config/auth.php" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/routes/api.php" beforeDir="false" afterPath="$PROJECT_DIR$/src/routes/api.php" afterDir="false" />
     </list>
     <option name="SHOW_DIALOG" value="false" />
     <option name="HIGHLIGHT_CONFLICTS" value="true" />
@@ -163,7 +166,7 @@
     "PHPUnit.メイン.executor": "Run",
     "RunOnceActivity.ShowReadmeOnStart": "true",
     "RunOnceActivity.git.unshallow": "true",
-    "git-widget-placeholder": "feature/user-logout-presentation-controller",
+    "git-widget-placeholder": "feature/user-logout-test-feature",
     "node.js.detected.package.eslint": "true",
     "node.js.selected.package.eslint": "(autodetect)",
     "nodejs_package_manager_path": "npm",

--- a/src/app/User/Tests/User_LoginTest.php
+++ b/src/app/User/Tests/User_LoginTest.php
@@ -6,7 +6,7 @@ use Tests\TestCase;
 use Illuminate\Support\Facades\DB;
 use App\Models\User;
 
-class User_loginTest extends TestCase
+class User_LoginTest extends TestCase
 {
     protected function setUp(): void
     {

--- a/src/app/User/Tests/User_LogoutTest.php
+++ b/src/app/User/Tests/User_LogoutTest.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace App\User\Tests;
+
+use App\Models\User;
+use Illuminate\Support\Facades\DB;
+use Tests\TestCase;
+use Firebase\JWT\JWT;
+use Illuminate\Support\Facades\Config;
+
+
+
+class User_LogoutTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->refresh();
+    }
+
+    protected function tearDown(): void
+    {
+        $this->refresh();
+        parent::tearDown();
+    }
+
+    protected function refresh()
+    {
+        if (env('APP_ENV') === 'testing') {
+            DB::connection('mysql')->statement('SET FOREIGN_KEY_CHECKS=0;');
+            User::truncate();
+            DB::connection('mysql')->statement('SET FOREIGN_KEY_CHECKS=1;');
+        }
+    }
+
+    public function test1(): void
+    {
+        Config::set('jwt.secret', 'test-secret-123'); // ← 明示的に上書き
+
+        $user = User::create([
+            'first_name' => 'Cristiano',
+            'last_name' => 'Ronaldo',
+            'email' => 'manchester_united7@test.com',
+            'password' => bcrypt('test1234'),
+            'bio' => null,
+            'location' => null,
+            'skills' => ['Laravel', 'React'],
+            'profile_image' => null,
+        ]);
+
+        $payload = [
+            'user_id' => $user->id,
+            'iat' => now()->timestamp,
+            'exp' => now()->addHour()->timestamp,
+        ];
+
+        $secret = config('jwt.secret');
+        $token = JWT::encode($payload, $secret, 'HS256');
+
+        $response = $this->withHeaders([
+            'Authorization' => "Bearer {$token}",
+        ])->postJson('/api/logout');
+
+        $response->assertStatus(200)
+            ->assertJson([
+                'status' => 'success',
+                'message' => 'User logged out successfully',
+            ]);
+    }
+}

--- a/src/config/auth.php
+++ b/src/config/auth.php
@@ -40,6 +40,12 @@ return [
             'driver' => 'session',
             'provider' => 'users',
         ],
+
+        'api' => [
+            'driver' => 'jwt',
+            'provider' => 'users',
+            'hash' => false,
+        ],
     ],
 
     /*

--- a/src/routes/api.php
+++ b/src/routes/api.php
@@ -3,9 +3,12 @@
 use App\User\Presentation\Controller\UserController;
 use Illuminate\Support\Facades\Route;
 
+
+Route::post('logout', [UserController::class, 'logout'])->name('logout');
+
 Route::prefix('users')->name('user.')->group(function () {
     Route::post('register', [UserController::class, 'createUser'])->name('register');
+    Route::post('login', [UserController::class, 'login'])->name('login');
     Route::get('/show/{id}', [UserController::class, 'showUser'])->name('show');
     Route::put('{id}', [UserController::class, 'update'])->name('update');
-    Route::post('login', [UserController::class, 'login'])->name('login');
 });


### PR DESCRIPTION
### Description
This pull request introduces a feature test to verify the logout functionality of a user authenticated via JWT. The test ensures that a valid JWT, once generated and attached to the request header, successfully triggers the logout endpoint and returns the expected 200 response with the appropriate success message.

Key aspects include:
- Test database is refreshed before and after each test run.
- A JWT is manually generated using a test secret key.
- The test mimics a full logout request using Laravel’s test client.
- The test asserts both HTTP status and JSON response body.