### PR TITLE
Implement PostEntity for domain layer with value objects and enum support

### DIFF
--- a/.idea/workspace.xml
+++ b/.idea/workspace.xml
@@ -5,12 +5,46 @@
   </component>
   <component name="ChangeListManager">
     <list default="true" id="6952a861-17ec-40ad-b866-c564752c14a8" name="変更" comment="fix: test-environment-fix">
-      <change afterPath="$PROJECT_DIR$/src/app/User/Tests/User_LogoutTest.php" afterDir="false" />
+      <change afterPath="$PROJECT_DIR$/src/app/Common/Domain/Enum/PostVisibility.php" afterDir="false" />
+      <change afterPath="$PROJECT_DIR$/src/app/Common/Domain/ValueObject/Postid.php" afterDir="false" />
+      <change afterPath="$PROJECT_DIR$/src/app/Post/Domain/DomainTest/PostEntityTest.php" afterDir="false" />
+      <change afterPath="$PROJECT_DIR$/src/app/Post/Domain/Entity/PostEntity.php" afterDir="false" />
+      <change afterPath="$PROJECT_DIR$/src/app/Post/Domain/ValueObject/Postvisibility.php" afterDir="false" />
       <change beforePath="$PROJECT_DIR$/.idea/workspace.xml" beforeDir="false" afterPath="$PROJECT_DIR$/.idea/workspace.xml" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/src/app/User/Presentation/Controller/UserController.php" beforeDir="false" afterPath="$PROJECT_DIR$/src/app/User/Presentation/Controller/UserController.php" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/src/app/User/Tests/User_loginTest.php" beforeDir="false" afterPath="$PROJECT_DIR$/src/app/User/Tests/User_LoginTest.php" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/src/config/auth.php" beforeDir="false" afterPath="$PROJECT_DIR$/src/config/auth.php" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/src/routes/api.php" beforeDir="false" afterPath="$PROJECT_DIR$/src/routes/api.php" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/app/Common/Domain/UserId.php" beforeDir="false" afterPath="$PROJECT_DIR$/src/app/Common/Domain/ValueObject/UserId.php" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/app/User/Application/ApplicationTest/LoginUserDtoTest.php" beforeDir="false" afterPath="$PROJECT_DIR$/src/app/User/Application/ApplicationTest/LoginUserDtoTest.php" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/app/User/Application/ApplicationTest/LogoutUserUseCaseTest.php" beforeDir="false" afterPath="$PROJECT_DIR$/src/app/User/Application/ApplicationTest/LogoutUserUseCaseTest.php" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/app/User/Application/ApplicationTest/RegisterUserDtoFactoryTest.php" beforeDir="false" afterPath="$PROJECT_DIR$/src/app/User/Application/ApplicationTest/RegisterUserDtoFactoryTest.php" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/app/User/Application/ApplicationTest/RegisterUserUseCaseTest.php" beforeDir="false" afterPath="$PROJECT_DIR$/src/app/User/Application/ApplicationTest/RegisterUserUseCaseTest.php" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/app/User/Application/ApplicationTest/ShowUserDtoTest.php" beforeDir="false" afterPath="$PROJECT_DIR$/src/app/User/Application/ApplicationTest/ShowUserDtoTest.php" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/app/User/Application/ApplicationTest/ShowUserUseCaseTest.php" beforeDir="false" afterPath="$PROJECT_DIR$/src/app/User/Application/ApplicationTest/ShowUserUseCaseTest.php" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/app/User/Application/ApplicationTest/UpdateUserDtoTest.php" beforeDir="false" afterPath="$PROJECT_DIR$/src/app/User/Application/ApplicationTest/UpdateUserDtoTest.php" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/app/User/Application/ApplicationTest/UpdateUserUseCaseTest.php" beforeDir="false" afterPath="$PROJECT_DIR$/src/app/User/Application/ApplicationTest/UpdateUserUseCaseTest.php" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/app/User/Application/Dto/LoginUserDto.php" beforeDir="false" afterPath="$PROJECT_DIR$/src/app/User/Application/Dto/LoginUserDto.php" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/app/User/Application/Dto/RegisterUserDto.php" beforeDir="false" afterPath="$PROJECT_DIR$/src/app/User/Application/Dto/RegisterUserDto.php" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/app/User/Application/Dto/ShowUserDto.php" beforeDir="false" afterPath="$PROJECT_DIR$/src/app/User/Application/Dto/ShowUserDto.php" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/app/User/Application/Dto/UpdateUserDto.php" beforeDir="false" afterPath="$PROJECT_DIR$/src/app/User/Application/Dto/UpdateUserDto.php" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/app/User/Application/Factory/RegisterUserDtoFactory.php" beforeDir="false" afterPath="$PROJECT_DIR$/src/app/User/Application/Factory/RegisterUserDtoFactory.php" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/app/User/Application/UseCase/LogoutUserUseCase.php" beforeDir="false" afterPath="$PROJECT_DIR$/src/app/User/Application/UseCase/LogoutUserUseCase.php" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/app/User/Application/UseCase/ShowUserUseCase.php" beforeDir="false" afterPath="$PROJECT_DIR$/src/app/User/Application/UseCase/ShowUserUseCase.php" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/app/User/Domain/DomainTest/UserUpdateEntityFactoryTest.php" beforeDir="false" afterPath="$PROJECT_DIR$/src/app/User/Domain/DomainTest/UserUpdateEntityFactoryTest.php" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/app/User/Domain/Entity/UserEntity.php" beforeDir="false" afterPath="$PROJECT_DIR$/src/app/User/Domain/Entity/UserEntity.php" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/app/User/Domain/Factory/UserEntityFactory.php" beforeDir="false" afterPath="$PROJECT_DIR$/src/app/User/Domain/Factory/UserEntityFactory.php" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/app/User/Domain/Factory/UserFromModelEntityFactory.php" beforeDir="false" afterPath="$PROJECT_DIR$/src/app/User/Domain/Factory/UserFromModelEntityFactory.php" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/app/User/Domain/Factory/UserUpdateEntityFactory.php" beforeDir="false" afterPath="$PROJECT_DIR$/src/app/User/Domain/Factory/UserUpdateEntityFactory.php" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/app/User/Domain/RepositoryInterface/UserRepositoryInterface.php" beforeDir="false" afterPath="$PROJECT_DIR$/src/app/User/Domain/RepositoryInterface/UserRepositoryInterface.php" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/app/User/Infrastructure/InfrastructureTest/GenerateTokenServiceTest.php" beforeDir="false" afterPath="$PROJECT_DIR$/src/app/User/Infrastructure/InfrastructureTest/GenerateTokenServiceTest.php" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/app/User/Infrastructure/InfrastructureTest/JwtAuthServiceTest.php" beforeDir="false" afterPath="$PROJECT_DIR$/src/app/User/Infrastructure/InfrastructureTest/JwtAuthServiceTest.php" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/app/User/Infrastructure/InfrastructureTest/UserRepository_findByIdTest.php" beforeDir="false" afterPath="$PROJECT_DIR$/src/app/User/Infrastructure/InfrastructureTest/UserRepository_findByIdTest.php" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/app/User/Infrastructure/InfrastructureTest/UserRepository_updateTest.php" beforeDir="false" afterPath="$PROJECT_DIR$/src/app/User/Infrastructure/InfrastructureTest/UserRepository_updateTest.php" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/app/User/Infrastructure/Repository/UserRepository.php" beforeDir="false" afterPath="$PROJECT_DIR$/src/app/User/Infrastructure/Repository/UserRepository.php" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/app/User/Presentation/PresentationTest/Controller/UserController_logoutTest.php" beforeDir="false" afterPath="$PROJECT_DIR$/src/app/User/Presentation/PresentationTest/Controller/UserController_logoutTest.php" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/app/User/Presentation/PresentationTest/Controller/UserController_registerTest.php" beforeDir="false" afterPath="$PROJECT_DIR$/src/app/User/Presentation/PresentationTest/Controller/UserController_registerTest.php" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/app/User/Presentation/PresentationTest/Controller/UserController_showTest.php" beforeDir="false" afterPath="$PROJECT_DIR$/src/app/User/Presentation/PresentationTest/Controller/UserController_showTest.php" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/app/User/Presentation/PresentationTest/Controller/UserController_updateTest.php" beforeDir="false" afterPath="$PROJECT_DIR$/src/app/User/Presentation/PresentationTest/Controller/UserController_updateTest.php" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/app/User/Presentation/PresentationTest/RegisterUserViewModelFactoryTest.php" beforeDir="false" afterPath="$PROJECT_DIR$/src/app/User/Presentation/PresentationTest/RegisterUserViewModelFactoryTest.php" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/app/User/Presentation/PresentationTest/ShowUserViewModelTest.php" beforeDir="false" afterPath="$PROJECT_DIR$/src/app/User/Presentation/PresentationTest/ShowUserViewModelTest.php" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/app/User/Presentation/PresentationTest/UpdateUserViewModelTest.php" beforeDir="false" afterPath="$PROJECT_DIR$/src/app/User/Presentation/PresentationTest/UpdateUserViewModelTest.php" afterDir="false" />
     </list>
     <option name="SHOW_DIALOG" value="false" />
     <option name="HIGHLIGHT_CONFLICTS" value="true" />
@@ -166,7 +200,7 @@
     "PHPUnit.メイン.executor": "Run",
     "RunOnceActivity.ShowReadmeOnStart": "true",
     "RunOnceActivity.git.unshallow": "true",
-    "git-widget-placeholder": "feature/user-logout-test-feature",
+    "git-widget-placeholder": "feature/create-post-domain-entity",
     "node.js.detected.package.eslint": "true",
     "node.js.selected.package.eslint": "(autodetect)",
     "nodejs_package_manager_path": "npm",

--- a/src/app/Common/Domain/Enum/PostVisibility.php
+++ b/src/app/Common/Domain/Enum/PostVisibility.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace App\Common\Domain\Enum;
+
+use InvalidArgumentException;
+
+enum PostVisibility: string
+{
+    case PUBLIC = 'public';
+    case PRIVATE = 'private';
+
+    public static function fromString(string $value): self
+    {
+        return match ($value) {
+            self::PUBLIC->value => self::PUBLIC,
+            self::PRIVATE->value => self::PRIVATE,
+            default => throw new InvalidArgumentException("Invalid PostVisibility: {$value}"),
+        };
+    }
+}

--- a/src/app/Common/Domain/ValueObject/Postid.php
+++ b/src/app/Common/Domain/ValueObject/Postid.php
@@ -1,17 +1,17 @@
 <?php
 
-namespace App\Common\Domain;
+namespace App\Common\Domain\ValueObject;
 
 use InvalidArgumentException;
 
-class UserId
+class PostId
 {
     private ?int $value;
 
     public function __construct(?int $value)
     {
         if (!is_null($value) && $value <= 0) {
-            throw new InvalidArgumentException('User Id must be a positive integer.');
+            throw new InvalidArgumentException('Post Id must be a positive integer.');
         }
 
         $this->value = $value;

--- a/src/app/Common/Domain/ValueObject/UserId.php
+++ b/src/app/Common/Domain/ValueObject/UserId.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace App\Common\Domain\ValueObject;
+
+use InvalidArgumentException;
+
+class UserId
+{
+    private ?int $value;
+
+    public function __construct(?int $value)
+    {
+        if (!is_null($value) && $value <= 0) {
+            throw new InvalidArgumentException('User Id must be a positive integer.');
+        }
+
+        $this->value = $value;
+    }
+
+    public function getValue(): ?int
+    {
+        return $this->value;
+    }
+}

--- a/src/app/Post/Domain/DomainTest/PostEntityTest.php
+++ b/src/app/Post/Domain/DomainTest/PostEntityTest.php
@@ -1,0 +1,65 @@
+<?php
+
+namespace App\Post\Domain\DomainTest;
+
+use Illuminate\Support\Arr;
+use Tests\TestCase;
+use App\Post\Domain\Entity\PostEntity;
+use App\Common\Domain\ValueObject\UserId;
+use App\Post\Domain\ValueObject\Postvisibility;
+use App\Common\Domain\ValueObject\PostId;
+use App\Common\Domain\Enum\PostVisibility as PostVisibilityEnum;
+
+class PostEntityTest extends TestCase
+{
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+    }
+
+    protected function tearDown(): void
+    {
+        parent::tearDown();
+    }
+
+    public function test_post_entity_check_value(): void
+    {
+        $result = PostEntity::build($this->arrayData());
+
+        $this->assertEquals($this->arrayData()['userId'], $result->getUserId()->getValue());
+        $this->assertEquals($this->arrayData()['content'], $result->getContent());
+        $this->assertEquals($this->arrayData()['mediaPath'], $result->getMediaPath());
+        $this->assertEquals($this->arrayData()['visibility'], $result->getPostVisibility()->getStringValue());
+    }
+
+    public function test_post_entity_check_value_with_post_id(): void
+    {
+        $newArr = array_merge(['id' => 1], $this->arrayData());
+
+        $result = PostEntity::build($newArr);
+
+        $this->assertEquals($newArr['id'], $result->getId()->getValue());
+        $this->assertEquals($newArr['userId'], $result->getUserId()->getValue());
+        $this->assertEquals($newArr['content'], $result->getContent());
+        $this->assertEquals($newArr['mediaPath'], $result->getMediaPath());
+        $this->assertEquals($newArr['visibility'], $result->getPostVisibility()->getStringValue());
+    }
+
+    public function test_post_entity_check_type(): void
+    {
+        $result = PostEntity::build($this->arrayData());
+
+        $this->assertInstanceOf(PostEntity::class, $result);
+    }
+
+    private function arrayData(): array
+    {
+        return [
+            'userId' => 1,
+            'content' => 'This is a test post.',
+            'mediaPath' => 'https://example.com/media.jpg',
+            'visibility' => 'public',
+        ];
+    }
+}

--- a/src/app/Post/Domain/Entity/PostEntity.php
+++ b/src/app/Post/Domain/Entity/PostEntity.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace App\Post\Domain\Entity;
+
+use App\Common\Domain\ValueObject\PostId;
+use App\Common\Domain\ValueObject\UserId;
+use App\Post\Domain\ValueObject\Postvisibility;
+use App\Common\Domain\Enum\PostVisibility as PostVisibilityEnum;
+
+class PostEntity
+{
+    public function __construct(
+        private readonly ?PostId $id,
+        private readonly UserId $userId,
+        private readonly string $content,
+        private readonly ?string $mediaPath,
+        private readonly Postvisibility $visibility
+    ){}
+
+    public static function build(array $request): self
+    {
+        return new self(
+            id: isset($request['id']) ? new PostId($request['id']) : null,
+            userId: new UserId($request['userId']),
+            content: $request['content'],
+            mediaPath: $request['mediaPath'] ?? null,
+            visibility: new Postvisibility(PostVisibilityEnum::fromString($request['visibility']))
+        );
+    }
+
+    public function getId(): ?PostId
+    {
+        return $this->id;
+    }
+
+    public function getUserId(): UserId
+    {
+        return $this->userId;
+    }
+
+    public function getContent(): string
+    {
+        return $this->content;
+    }
+
+    public function getMediaPath(): ?string
+    {
+        return $this->mediaPath;
+    }
+
+    public function getPostVisibility(): Postvisibility
+    {
+        return $this->visibility;
+    }
+}

--- a/src/app/Post/Domain/ValueObject/Postvisibility.php
+++ b/src/app/Post/Domain/ValueObject/Postvisibility.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace App\Post\Domain\ValueObject;
+
+use App\Common\Domain\Enum\PostVisibility as PostVisibilityEnum;
+use InvalidArgumentException;
+
+class Postvisibility
+{
+    public function __construct(
+        private readonly PostVisibilityEnum $enum
+    ) {
+        if (!in_array($this->enum->value, [PostVisibilityEnum::PUBLIC->value, PostVisibilityEnum::PRIVATE->value])) {
+            throw new InvalidArgumentException('Invalid post visibility value.');
+        }
+    }
+
+    public function getValue(): PostVisibilityEnum
+    {
+        return $this->enum;
+    }
+
+    public function getStringValue(): string
+    {
+        return $this->enum->value;
+    }
+}

--- a/src/app/User/Application/ApplicationTest/LoginUserDtoTest.php
+++ b/src/app/User/Application/ApplicationTest/LoginUserDtoTest.php
@@ -2,14 +2,14 @@
 
 namespace App\User\Application\ApplicationTest;
 
-use App\User\Domain\Factory\UserEntityFactory;
-use Tests\TestCase;
-use App\Common\Domain\UserId;
-use Mockery;
-use App\User\Domain\Entity\UserEntity;
 use App\User\Application\Dto\LoginUserDto;
+use App\User\Domain\Entity\UserEntity;
+use App\User\Domain\Factory\UserEntityFactory;
 use App\User\Domain\ValueObject\AuthToken;
 use App\User\Domain\ValueObject\Email;
+use Common\Domain\ValueObjet\UserId;
+use Mockery;
+use Tests\TestCase;
 
 class LoginUserDtoTest extends TestCase
 {

--- a/src/app/User/Application/ApplicationTest/LogoutUserUseCaseTest.php
+++ b/src/app/User/Application/ApplicationTest/LogoutUserUseCaseTest.php
@@ -2,16 +2,15 @@
 
 namespace App\User\Application\ApplicationTest;
 
-use App\Common\Domain\UserId;
-use App\User\Domain\RepositoryInterface\UserRepositoryInterface;
-use App\User\Infrastructure\Repository\UserRepository;
-use Tests\TestCase;
 use App\User\Application\UseCase\LogoutUserUseCase;
-use App\User\Domain\Service\AuthServiceInterface;
 use App\User\Domain\Entity\UserEntity;
-use Mockery;
 use App\User\Domain\Factory\UserEntityFactory;
 use App\User\Domain\RepositoryInterface\PasswordHasherInterface;
+use App\User\Domain\RepositoryInterface\UserRepositoryInterface;
+use App\User\Domain\Service\AuthServiceInterface;
+use Common\Domain\ValueObjet\UserId;
+use Mockery;
+use Tests\TestCase;
 
 class LogoutUserUseCaseTest extends TestCase
 {

--- a/src/app/User/Application/ApplicationTest/RegisterUserDtoFactoryTest.php
+++ b/src/app/User/Application/ApplicationTest/RegisterUserDtoFactoryTest.php
@@ -2,15 +2,14 @@
 
 namespace App\User\Application\ApplicationTest;
 
+use App\User\Application\Dto\RegisterUserDto;
+use App\User\Application\Factory\RegisterUserDtoFactory;
 use App\User\Domain\Entity\UserEntity;
 use App\User\Domain\Factory\UserEntityFactory;
-use Tests\TestCase;
-use App\User\Application\Factory\RegisterUserDtoFactory;
-use App\User\Application\Dto\RegisterUserDto;
 use App\User\Domain\ValueObject\Email;
-use App\Common\Domain\UserId;
-use App\Models\User;
+use Common\Domain\ValueObjet\UserId;
 use Mockery;
+use Tests\TestCase;
 
 class RegisterUserDtoFactoryTest extends TestCase
 {

--- a/src/app/User/Application/ApplicationTest/RegisterUserUseCaseTest.php
+++ b/src/app/User/Application/ApplicationTest/RegisterUserUseCaseTest.php
@@ -2,19 +2,19 @@
 
 namespace App\User\Application\ApplicationTest;
 
-use App\User\Application\UseCase\RegisterUserUsecase;
-use App\User\Infrastructure\Repository\UserRepository;
-use App\User\Domain\Factory\UserEntityFactory;
 use App\User\Application\Dto\RegisterUserDto;
-use App\User\Application\Factory\RegisterUserDtoFactory;
-use App\User\Application\UseCommand\RegisterUserCommand;
 use App\User\Application\Factory\RegisterUserCommandFactory;
+use App\User\Application\Factory\RegisterUserDtoFactory;
+use App\User\Application\UseCase\RegisterUserUsecase;
+use App\User\Application\UseCommand\RegisterUserCommand;
 use App\User\Domain\Entity\UserEntity;
-use Tests\TestCase;
-use Mockery;
-use App\Common\Domain\UserId;
-use App\User\Domain\ValueObject\Email;
+use App\User\Domain\Factory\UserEntityFactory;
 use App\User\Domain\RepositoryInterface\PasswordHasherInterface;
+use App\User\Domain\ValueObject\Email;
+use App\User\Infrastructure\Repository\UserRepository;
+use Common\Domain\ValueObjet\UserId;
+use Mockery;
+use Tests\TestCase;
 
 class RegisterUserUseCaseTest extends TestCase
 {

--- a/src/app/User/Application/ApplicationTest/ShowUserDtoTest.php
+++ b/src/app/User/Application/ApplicationTest/ShowUserDtoTest.php
@@ -2,13 +2,13 @@
 
 namespace App\User\Application\ApplicationTest;
 
-use App\Common\Domain\UserId;
 use App\User\Application\Dto\ShowUserDto;
 use App\User\Domain\Entity\UserEntity;
 use App\User\Domain\Factory\UserFromModelEntityFactory;
-use Tests\TestCase;
 use App\User\Domain\ValueObject\Email;
+use Common\Domain\ValueObjet\UserId;
 use Mockery;
+use Tests\TestCase;
 
 class ShowUserDtoTest extends TestCase
 {

--- a/src/app/User/Application/ApplicationTest/ShowUserUseCaseTest.php
+++ b/src/app/User/Application/ApplicationTest/ShowUserUseCaseTest.php
@@ -3,15 +3,15 @@
 namespace App\User\Application\ApplicationTest;
 
 use App\Models\User;
-use Tests\TestCase;
+use App\User\Application\Dto\ShowUserDto;
 use App\User\Application\UseCase\ShowUserUseCase;
+use App\User\Domain\Entity\UserEntity;
 use App\User\Domain\Factory\UserFromModelEntityFactory;
 use App\User\Domain\RepositoryInterface\UserRepositoryInterface;
-use App\User\Domain\Entity\UserEntity;
 use App\User\Domain\ValueObject\Email;
-use App\User\Application\Dto\ShowUserDto;
+use Common\Domain\ValueObjet\UserId;
 use Mockery;
-use App\Common\Domain\UserId;
+use Tests\TestCase;
 
 class ShowUserUseCaseTest extends TestCase
 {

--- a/src/app/User/Application/ApplicationTest/UpdateUserDtoTest.php
+++ b/src/app/User/Application/ApplicationTest/UpdateUserDtoTest.php
@@ -2,13 +2,13 @@
 
 namespace App\User\Application\ApplicationTest;
 
-use Tests\TestCase;
 use App\User\Application\Dto\UpdateUserDto;
 use App\User\Domain\Entity\UserEntity;
-use App\User\Domain\ValueObject\Email;
-use App\Common\Domain\UserId;
-use Mockery;
 use App\User\Domain\Factory\UserUpdateEntityFactory;
+use App\User\Domain\ValueObject\Email;
+use Common\Domain\ValueObjet\UserId;
+use Mockery;
+use Tests\TestCase;
 
 class UpdateUserDtoTest extends TestCase
 {

--- a/src/app/User/Application/ApplicationTest/UpdateUserUseCaseTest.php
+++ b/src/app/User/Application/ApplicationTest/UpdateUserUseCaseTest.php
@@ -2,16 +2,16 @@
 
 namespace App\User\Application\UseCase;
 
-use App\Common\Domain\UserId;
+use App\User\Application\Dto\UpdateUserDto;
+use App\User\Application\UseCommand\UpdateUserCommand;
+use App\User\Domain\Entity\UserEntity;
 use App\User\Domain\Factory\UserFromModelEntityFactory;
 use App\User\Domain\Factory\UserUpdateEntityFactory;
-use App\User\Domain\ValueObject\Email;
-use Tests\TestCase;
-use Mockery;
-use App\User\Application\UseCommand\UpdateUserCommand;
-use App\User\Application\Dto\UpdateUserDto;
 use App\User\Domain\RepositoryInterface\UserRepositoryInterface;
-use App\User\Domain\Entity\UserEntity;
+use App\User\Domain\ValueObject\Email;
+use Common\Domain\ValueObjet\UserId;
+use Mockery;
+use Tests\TestCase;
 
 class UpdateUserUseCaseTest extends TestCase
 {

--- a/src/app/User/Application/Dto/LoginUserDto.php
+++ b/src/app/User/Application/Dto/LoginUserDto.php
@@ -2,10 +2,10 @@
 
 namespace App\User\Application\Dto;
 
-use App\Common\Domain\UserId;
 use App\User\Domain\Entity\UserEntity;
 use App\User\Domain\ValueObject\AuthToken;
 use App\User\Domain\ValueObject\Email;
+use Common\Domain\ValueObjet\UserId;
 
 class LoginUserDto
 {

--- a/src/app/User/Application/Dto/RegisterUserDto.php
+++ b/src/app/User/Application/Dto/RegisterUserDto.php
@@ -2,8 +2,8 @@
 
 namespace App\User\Application\Dto;
 
-use App\Common\Domain\UserId;
 use App\User\Domain\ValueObject\Email;
+use Common\Domain\ValueObjet\UserId;
 
 class RegisterUserDto
 {

--- a/src/app/User/Application/Dto/ShowUserDto.php
+++ b/src/app/User/Application/Dto/ShowUserDto.php
@@ -2,9 +2,9 @@
 
 namespace App\User\Application\Dto;
 
-use App\Common\Domain\UserId;
 use App\User\Domain\Entity\UserEntity;
 use App\User\Domain\ValueObject\Email;
+use Common\Domain\ValueObjet\UserId;
 
 class ShowUserDto
 {

--- a/src/app/User/Application/Dto/UpdateUserDto.php
+++ b/src/app/User/Application/Dto/UpdateUserDto.php
@@ -2,9 +2,9 @@
 
 namespace App\User\Application\Dto;
 
-use App\Common\Domain\UserId;
 use App\User\Domain\Entity\UserEntity;
 use App\User\Domain\ValueObject\Email;
+use Common\Domain\ValueObjet\UserId;
 
 class UpdateUserDto
 {

--- a/src/app/User/Application/Factory/RegisterUserDtoFactory.php
+++ b/src/app/User/Application/Factory/RegisterUserDtoFactory.php
@@ -2,10 +2,10 @@
 
 namespace App\User\Application\Factory;
 
+use App\User\Application\Dto\RegisterUserDto;
 use App\User\Domain\Entity\UserEntity;
 use App\User\Domain\ValueObject\Email;
-use App\Common\Domain\UserId;
-use App\User\Application\Dto\RegisterUserDto;
+use Common\Domain\ValueObjet\UserId;
 
 class RegisterUserDtoFactory
 {

--- a/src/app/User/Application/UseCase/LogoutUserUseCase.php
+++ b/src/app/User/Application/UseCase/LogoutUserUseCase.php
@@ -4,8 +4,7 @@ namespace App\User\Application\UseCase;
 
 use App\User\Domain\RepositoryInterface\UserRepositoryInterface;
 use App\User\Domain\Service\AuthServiceInterface;
-use App\User\Domain\Entity\UserEntity;
-use App\Common\Domain\UserId;
+use Common\Domain\ValueObjet\UserId;
 
 class LogoutUserUseCase
 {

--- a/src/app/User/Application/UseCase/ShowUserUseCase.php
+++ b/src/app/User/Application/UseCase/ShowUserUseCase.php
@@ -2,12 +2,9 @@
 
 namespace App\User\Application\UseCase;
 
-use App\Common\Domain\UserId;
-use App\Models\User;
-use App\User\Domain\RepositoryInterface\UserRepositoryInterface;
 use App\User\Application\Dto\ShowUserDto;
-use App\User\Domain\Factory\UserFromModelEntityFactory;
-use Exception;
+use App\User\Domain\RepositoryInterface\UserRepositoryInterface;
+use Common\Domain\ValueObjet\UserId;
 
 class ShowUserUseCase
 {

--- a/src/app/User/Domain/DomainTest/UserUpdateEntityFactoryTest.php
+++ b/src/app/User/Domain/DomainTest/UserUpdateEntityFactoryTest.php
@@ -3,12 +3,10 @@
 namespace App\User\Domain\DomainTest;
 
 use App\User\Application\UseCommand\UpdateUserCommand;
+use App\User\Domain\Entity\UserEntity;
+use App\User\Domain\Factory\UserUpdateEntityFactory;
 use Mockery;
 use Tests\TestCase;
-use App\User\Domain\Entity\UserEntity;
-use App\Common\Domain\UserId;
-use App\User\Domain\ValueObject\Email;
-use App\User\Domain\Factory\UserUpdateEntityFactory;
 
 class UserUpdateEntityFactoryTest extends TestCase
 {

--- a/src/app/User/Domain/Entity/UserEntity.php
+++ b/src/app/User/Domain/Entity/UserEntity.php
@@ -2,9 +2,9 @@
 
 namespace App\User\Domain\Entity;
 
-use App\Common\Domain\UserId;
 use App\User\Domain\ValueObject\Email;
 use App\User\Domain\ValueObject\Password;
+use Common\Domain\ValueObjet\UserId;
 use LogicException;
 
 class UserEntity

--- a/src/app/User/Domain/Factory/UserEntityFactory.php
+++ b/src/app/User/Domain/Factory/UserEntityFactory.php
@@ -3,10 +3,10 @@
 namespace App\User\Domain\Factory;
 
 use App\User\Domain\Entity\UserEntity;
+use App\User\Domain\RepositoryInterface\PasswordHasherInterface;
 use App\User\Domain\ValueObject\Email;
 use App\User\Domain\ValueObject\Password;
-use App\Common\Domain\UserId;
-use App\User\Domain\RepositoryInterface\PasswordHasherInterface;
+use Common\Domain\ValueObjet\UserId;
 
 class UserEntityFactory
 {

--- a/src/app/User/Domain/Factory/UserFromModelEntityFactory.php
+++ b/src/app/User/Domain/Factory/UserFromModelEntityFactory.php
@@ -6,7 +6,7 @@ use App\Models\User;
 use App\User\Domain\Entity\UserEntity;
 use App\User\Domain\ValueObject\Email;
 use App\User\Domain\ValueObject\Password;
-use App\Common\Domain\UserId;
+use Common\Domain\ValueObjet\UserId;
 
 class UserFromModelEntityFactory
 {

--- a/src/app/User/Domain/Factory/UserUpdateEntityFactory.php
+++ b/src/app/User/Domain/Factory/UserUpdateEntityFactory.php
@@ -4,8 +4,8 @@ namespace App\User\Domain\Factory;
 
 use App\User\Application\UseCommand\UpdateUserCommand;
 use App\User\Domain\Entity\UserEntity;
-use App\Common\Domain\UserId;
 use App\User\Domain\ValueObject\Email;
+use Common\Domain\ValueObjet\UserId;
 
 class UserUpdateEntityFactory
 {

--- a/src/app/User/Domain/RepositoryInterface/UserRepositoryInterface.php
+++ b/src/app/User/Domain/RepositoryInterface/UserRepositoryInterface.php
@@ -2,9 +2,9 @@
 
 namespace App\User\Domain\RepositoryInterface;
 
-use App\Common\Domain\UserId;
 use App\User\Domain\Entity\UserEntity;
 use App\User\Domain\ValueObject\Email;
+use Common\Domain\ValueObjet\UserId;
 
 interface UserRepositoryInterface
 {

--- a/src/app/User/Infrastructure/InfrastructureTest/GenerateTokenServiceTest.php
+++ b/src/app/User/Infrastructure/InfrastructureTest/GenerateTokenServiceTest.php
@@ -2,22 +2,22 @@
 
 namespace User\Infrastructure\InfrastructureTest;
 
-use App\Common\Domain\UserId;
 use App\Models\User;
+use App\User\Domain\Entity\UserEntity;
+use App\User\Domain\Factory\UserEntityFactory;
 use App\User\Domain\Factory\UserFromModelEntityFactory;
 use App\User\Domain\RepositoryInterface\PasswordHasherInterface;
-use App\User\Infrastructure\Repository\UserRepository;
-use Illuminate\Support\Facades\DB;
-use Tests\TestCase;
-use App\User\Infrastructure\Service\GenerateTokenService;
-use App\User\Domain\Entity\UserEntity;
 use App\User\Domain\ValueObject\AuthToken;
 use App\User\Domain\ValueObject\Email;
 use App\User\Domain\ValueObject\Password;
-use App\User\Domain\Factory\UserEntityFactory;
-use Mockery;
+use App\User\Infrastructure\Repository\UserRepository;
+use App\User\Infrastructure\Service\GenerateTokenService;
+use Common\Domain\ValueObjet\UserId;
 use Firebase\JWT\JWT;
 use Firebase\JWT\Key;
+use Illuminate\Support\Facades\DB;
+use Mockery;
+use Tests\TestCase;
 
 class GenerateTokenServiceTest extends TestCase
 {

--- a/src/app/User/Infrastructure/InfrastructureTest/JwtAuthServiceTest.php
+++ b/src/app/User/Infrastructure/InfrastructureTest/JwtAuthServiceTest.php
@@ -2,19 +2,19 @@
 
 namespace User\Infrastructure\InfrastructureTest;
 
-use App\Common\Domain\UserId;
 use App\Models\User;
+use App\User\Domain\Entity\UserEntity;
 use App\User\Domain\Factory\UserFromModelEntityFactory;
 use App\User\Domain\RepositoryInterface\PasswordHasherInterface;
-use App\User\Infrastructure\Repository\UserRepository;
-use Illuminate\Support\Facades\DB;
-use Tests\TestCase;
-use Mockery;
-use App\User\Domain\Entity\UserEntity;
+use App\User\Domain\RepositoryInterface\UserRepositoryInterface;
 use App\User\Domain\ValueObject\Email;
 use App\User\Domain\ValueObject\Password;
+use App\User\Infrastructure\Repository\UserRepository;
 use App\User\Infrastructure\Service\JwtAuthService;
-use App\User\Domain\RepositoryInterface\UserRepositoryInterface;
+use Common\Domain\ValueObjet\UserId;
+use Illuminate\Support\Facades\DB;
+use Mockery;
+use Tests\TestCase;
 
 class JwtAuthServiceTest extends TestCase
 {

--- a/src/app/User/Infrastructure/InfrastructureTest/UserRepository_findByIdTest.php
+++ b/src/app/User/Infrastructure/InfrastructureTest/UserRepository_findByIdTest.php
@@ -2,19 +2,18 @@
 
 namespace App\User\Infrastructure\InfrastructureTest;
 
-use App\User\Domain\Factory\UserEntityFactory;
-use App\User\Domain\RepositoryInterface\PasswordHasherInterface;
-use Tests\TestCase;
-use Illuminate\Support\Facades\DB;
 use App\Models\User;
 use App\User\Domain\Entity\UserEntity;
+use App\User\Domain\Factory\UserEntityFactory;
 use App\User\Domain\Factory\UserFromModelEntityFactory;
-use App\User\Infrastructure\Repository\UserRepository;
-use App\User\Domain\RepositoryInterface\UserRepositoryInterface;
-use App\Common\Domain\UserId;
+use App\User\Domain\RepositoryInterface\PasswordHasherInterface;
 use App\User\Domain\ValueObject\Email;
 use App\User\Domain\ValueObject\Password;
+use App\User\Infrastructure\Repository\UserRepository;
+use Common\Domain\ValueObjet\UserId;
+use Illuminate\Support\Facades\DB;
 use Mockery;
+use Tests\TestCase;
 
 class UserRepository_findByIdTest extends TestCase
 {

--- a/src/app/User/Infrastructure/InfrastructureTest/UserRepository_updateTest.php
+++ b/src/app/User/Infrastructure/InfrastructureTest/UserRepository_updateTest.php
@@ -2,16 +2,16 @@
 
 namespace App\User\Infrastructure\InfrastructureTest;
 
-use App\User\Domain\RepositoryInterface\PasswordHasherInterface;
-use App\User\Infrastructure\Repository\UserRepository;
-use Tests\TestCase;
-use Mockery;
-use App\User\Domain\Entity\UserEntity;
-use App\User\Domain\ValueObject\Email;
-use App\Common\Domain\UserId;
-use App\User\Domain\Factory\UserUpdateEntityFactory;
-use Illuminate\Support\Facades\DB;
 use App\Models\User;
+use App\User\Domain\Entity\UserEntity;
+use App\User\Domain\Factory\UserUpdateEntityFactory;
+use App\User\Domain\RepositoryInterface\PasswordHasherInterface;
+use App\User\Domain\ValueObject\Email;
+use App\User\Infrastructure\Repository\UserRepository;
+use Common\Domain\ValueObjet\UserId;
+use Illuminate\Support\Facades\DB;
+use Mockery;
+use Tests\TestCase;
 
 class UserRepository_updateTest extends TestCase
 {

--- a/src/app/User/Infrastructure/Repository/UserRepository.php
+++ b/src/app/User/Infrastructure/Repository/UserRepository.php
@@ -2,15 +2,15 @@
 
 namespace App\User\Infrastructure\Repository;
 
-use App\Common\Domain\UserId;
 use App\Models\User;
 use App\User\Domain\Entity\UserEntity;
 use App\User\Domain\Factory\UserFromModelEntityFactory;
+use App\User\Domain\RepositoryInterface\PasswordHasherInterface;
 use App\User\Domain\RepositoryInterface\UserRepositoryInterface;
 use App\User\Domain\ValueObject\Email;
-use App\User\Domain\RepositoryInterface\PasswordHasherInterface;
-use LogicException;
+use Common\Domain\ValueObjet\UserId;
 use Exception;
+use LogicException;
 
 class UserRepository implements UserRepositoryInterface
 {

--- a/src/app/User/Presentation/PresentationTest/Controller/UserController_logoutTest.php
+++ b/src/app/User/Presentation/PresentationTest/Controller/UserController_logoutTest.php
@@ -2,19 +2,19 @@
 
 namespace App\User\Presentation\PresentationTest\Controller;
 
+use App\Models\User;
 use App\User\Application\UseCase\LogoutUserUseCase;
+use App\User\Domain\Entity\UserEntity;
+use App\User\Domain\Factory\UserEntityFactory;
 use App\User\Domain\RepositoryInterface\PasswordHasherInterface;
 use App\User\Domain\RepositoryInterface\UserRepositoryInterface;
 use App\User\Domain\Service\AuthServiceInterface;
+use App\User\Presentation\Controller\UserController;
+use Common\Domain\ValueObjet\UserId;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\DB;
-use Tests\TestCase;
-use App\User\Presentation\Controller\UserController;
 use Mockery;
-use App\User\Domain\Entity\UserEntity;
-use App\User\Domain\Factory\UserEntityFactory;
-use App\Common\Domain\UserId;
-use App\Models\User;
+use Tests\TestCase;
 
 class UserController_logoutTest extends TestCase
 {

--- a/src/app/User/Presentation/PresentationTest/Controller/UserController_registerTest.php
+++ b/src/app/User/Presentation/PresentationTest/Controller/UserController_registerTest.php
@@ -2,15 +2,15 @@
 
 namespace App\User\Presentation\PresentationTest\Controller;
 
-use App\Common\Domain\UserId;
+use App\User\Application\Dto\RegisterUserDto;
 use App\User\Application\UseCase\RegisterUserUsecase;
 use App\User\Application\UseCommand\RegisterUserCommand;
-use App\User\Presentation\Controller\UserController;
-use App\User\Application\Dto\RegisterUserDto;
-use Illuminate\Http\Request;
 use App\User\Domain\ValueObject\Email;
-use Tests\TestCase;
+use App\User\Presentation\Controller\UserController;
+use Common\Domain\ValueObjet\UserId;
+use Illuminate\Http\Request;
 use Mockery;
+use Tests\TestCase;
 
 class UserController_registerTest extends TestCase
 {

--- a/src/app/User/Presentation/PresentationTest/Controller/UserController_showTest.php
+++ b/src/app/User/Presentation/PresentationTest/Controller/UserController_showTest.php
@@ -4,13 +4,13 @@ namespace App\User\Presentation\PresentationTest\Controller;
 
 use App\User\Application\Dto\ShowUserDto;
 use App\User\Application\UseCase\ShowUserUseCase;
+use App\User\Domain\ValueObject\Email;
 use App\User\Presentation\Controller\UserController;
 use App\User\Presentation\ViewModel\ShowUserViewModel;
+use Common\Domain\ValueObjet\UserId;
 use Illuminate\Http\JsonResponse;
-use Tests\TestCase;
 use Mockery;
-use App\Common\Domain\UserId;
-use App\User\Domain\ValueObject\Email;
+use Tests\TestCase;
 
 class UserController_showTest extends TestCase
 {

--- a/src/app/User/Presentation/PresentationTest/Controller/UserController_updateTest.php
+++ b/src/app/User/Presentation/PresentationTest/Controller/UserController_updateTest.php
@@ -2,16 +2,16 @@
 
 namespace App\User\Presentation\PresentationTest\Controller;
 
-use App\Common\Domain\UserId;
 use App\User\Application\Dto\UpdateUserDto;
 use App\User\Application\UseCase\UpdateUseCase;
 use App\User\Application\UseCommand\UpdateUserCommand;
 use App\User\Domain\ValueObject\Email;
 use App\User\Presentation\Controller\UserController;
+use Common\Domain\ValueObjet\UserId;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
-use Tests\TestCase;
 use Mockery;
+use Tests\TestCase;
 
 class UserController_updateTest extends TestCase
 {

--- a/src/app/User/Presentation/PresentationTest/RegisterUserViewModelFactoryTest.php
+++ b/src/app/User/Presentation/PresentationTest/RegisterUserViewModelFactoryTest.php
@@ -3,13 +3,13 @@
 namespace App\User\Presentation\PresentationTest;
 
 use App\User\Application\Dto\RegisterUserDto;
-use Tests\TestCase;
-use App\User\Presentation\ViewModel\Factory\RegisterUserViewModelFactory;
-use Mockery;
 use App\User\Application\Factory\RegisterUserDtoFactory;
-use App\User\Presentation\ViewModel\RegisterUserViewModel;
-use App\Common\Domain\UserId;
 use App\User\Domain\ValueObject\Email;
+use App\User\Presentation\ViewModel\Factory\RegisterUserViewModelFactory;
+use App\User\Presentation\ViewModel\RegisterUserViewModel;
+use Common\Domain\ValueObjet\UserId;
+use Mockery;
+use Tests\TestCase;
 
 class RegisterUserViewModelFactoryTest extends TestCase
 {

--- a/src/app/User/Presentation/PresentationTest/ShowUserViewModelTest.php
+++ b/src/app/User/Presentation/PresentationTest/ShowUserViewModelTest.php
@@ -3,11 +3,11 @@
 namespace App\User\Presentation\PresentationTest;
 
 use App\User\Application\Dto\ShowUserDto;
-use App\User\Presentation\ViewModel\ShowUserViewModel;
-use Tests\TestCase;
-use Mockery;
 use App\User\Domain\ValueObject\Email;
-use App\Common\Domain\UserId;
+use App\User\Presentation\ViewModel\ShowUserViewModel;
+use Common\Domain\ValueObjet\UserId;
+use Mockery;
+use Tests\TestCase;
 
 class ShowUserViewModelTest extends TestCase
 {

--- a/src/app/User/Presentation/PresentationTest/UpdateUserViewModelTest.php
+++ b/src/app/User/Presentation/PresentationTest/UpdateUserViewModelTest.php
@@ -2,12 +2,12 @@
 
 namespace App\User\Presentation\PresentationTest;
 
-use App\Common\Domain\UserId;
 use App\User\Application\Dto\UpdateUserDto;
 use App\User\Domain\ValueObject\Email;
 use App\User\Presentation\ViewModel\UpdateUserViewModel;
-use Tests\TestCase;
+use Common\Domain\ValueObjet\UserId;
 use Mockery;
+use Tests\TestCase;
 
 class UpdateUserViewModelTest extends TestCase
 {


### PR DESCRIPTION
### Description

This PR introduces the `PostEntity` within the domain layer. It encapsulates post-related attributes using strong typing and domain-driven constructs.

**Key points:**
- Added `PostEntity` class with the following properties: `PostId`, `UserId`, `content`, `mediaPath`, `PostVisibility`.
- Introduced a factory method `build(array $request)` for instantiation from request-like data.
- Utilised `PostVisibility` enum and corresponding value object to ensure valid visibility states.
- Designed for immutability and strict type control to reinforce domain consistency.
