### PR TITLE
Create PostRepositoryInterface to define domain persistence contract

### DIFF
--- a/.idea/workspace.xml
+++ b/.idea/workspace.xml
@@ -5,46 +5,8 @@
   </component>
   <component name="ChangeListManager">
     <list default="true" id="6952a861-17ec-40ad-b866-c564752c14a8" name="変更" comment="fix: test-environment-fix">
-      <change afterPath="$PROJECT_DIR$/src/app/Common/Domain/Enum/PostVisibility.php" afterDir="false" />
-      <change afterPath="$PROJECT_DIR$/src/app/Common/Domain/ValueObject/Postid.php" afterDir="false" />
-      <change afterPath="$PROJECT_DIR$/src/app/Post/Domain/DomainTest/PostEntityTest.php" afterDir="false" />
-      <change afterPath="$PROJECT_DIR$/src/app/Post/Domain/Entity/PostEntity.php" afterDir="false" />
-      <change afterPath="$PROJECT_DIR$/src/app/Post/Domain/ValueObject/Postvisibility.php" afterDir="false" />
+      <change afterPath="$PROJECT_DIR$/src/app/Post/Domain/RepositoryInterface/PostRepositoryInterface.php" afterDir="false" />
       <change beforePath="$PROJECT_DIR$/.idea/workspace.xml" beforeDir="false" afterPath="$PROJECT_DIR$/.idea/workspace.xml" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/src/app/Common/Domain/UserId.php" beforeDir="false" afterPath="$PROJECT_DIR$/src/app/Common/Domain/ValueObject/UserId.php" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/src/app/User/Application/ApplicationTest/LoginUserDtoTest.php" beforeDir="false" afterPath="$PROJECT_DIR$/src/app/User/Application/ApplicationTest/LoginUserDtoTest.php" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/src/app/User/Application/ApplicationTest/LogoutUserUseCaseTest.php" beforeDir="false" afterPath="$PROJECT_DIR$/src/app/User/Application/ApplicationTest/LogoutUserUseCaseTest.php" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/src/app/User/Application/ApplicationTest/RegisterUserDtoFactoryTest.php" beforeDir="false" afterPath="$PROJECT_DIR$/src/app/User/Application/ApplicationTest/RegisterUserDtoFactoryTest.php" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/src/app/User/Application/ApplicationTest/RegisterUserUseCaseTest.php" beforeDir="false" afterPath="$PROJECT_DIR$/src/app/User/Application/ApplicationTest/RegisterUserUseCaseTest.php" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/src/app/User/Application/ApplicationTest/ShowUserDtoTest.php" beforeDir="false" afterPath="$PROJECT_DIR$/src/app/User/Application/ApplicationTest/ShowUserDtoTest.php" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/src/app/User/Application/ApplicationTest/ShowUserUseCaseTest.php" beforeDir="false" afterPath="$PROJECT_DIR$/src/app/User/Application/ApplicationTest/ShowUserUseCaseTest.php" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/src/app/User/Application/ApplicationTest/UpdateUserDtoTest.php" beforeDir="false" afterPath="$PROJECT_DIR$/src/app/User/Application/ApplicationTest/UpdateUserDtoTest.php" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/src/app/User/Application/ApplicationTest/UpdateUserUseCaseTest.php" beforeDir="false" afterPath="$PROJECT_DIR$/src/app/User/Application/ApplicationTest/UpdateUserUseCaseTest.php" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/src/app/User/Application/Dto/LoginUserDto.php" beforeDir="false" afterPath="$PROJECT_DIR$/src/app/User/Application/Dto/LoginUserDto.php" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/src/app/User/Application/Dto/RegisterUserDto.php" beforeDir="false" afterPath="$PROJECT_DIR$/src/app/User/Application/Dto/RegisterUserDto.php" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/src/app/User/Application/Dto/ShowUserDto.php" beforeDir="false" afterPath="$PROJECT_DIR$/src/app/User/Application/Dto/ShowUserDto.php" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/src/app/User/Application/Dto/UpdateUserDto.php" beforeDir="false" afterPath="$PROJECT_DIR$/src/app/User/Application/Dto/UpdateUserDto.php" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/src/app/User/Application/Factory/RegisterUserDtoFactory.php" beforeDir="false" afterPath="$PROJECT_DIR$/src/app/User/Application/Factory/RegisterUserDtoFactory.php" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/src/app/User/Application/UseCase/LogoutUserUseCase.php" beforeDir="false" afterPath="$PROJECT_DIR$/src/app/User/Application/UseCase/LogoutUserUseCase.php" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/src/app/User/Application/UseCase/ShowUserUseCase.php" beforeDir="false" afterPath="$PROJECT_DIR$/src/app/User/Application/UseCase/ShowUserUseCase.php" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/src/app/User/Domain/DomainTest/UserUpdateEntityFactoryTest.php" beforeDir="false" afterPath="$PROJECT_DIR$/src/app/User/Domain/DomainTest/UserUpdateEntityFactoryTest.php" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/src/app/User/Domain/Entity/UserEntity.php" beforeDir="false" afterPath="$PROJECT_DIR$/src/app/User/Domain/Entity/UserEntity.php" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/src/app/User/Domain/Factory/UserEntityFactory.php" beforeDir="false" afterPath="$PROJECT_DIR$/src/app/User/Domain/Factory/UserEntityFactory.php" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/src/app/User/Domain/Factory/UserFromModelEntityFactory.php" beforeDir="false" afterPath="$PROJECT_DIR$/src/app/User/Domain/Factory/UserFromModelEntityFactory.php" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/src/app/User/Domain/Factory/UserUpdateEntityFactory.php" beforeDir="false" afterPath="$PROJECT_DIR$/src/app/User/Domain/Factory/UserUpdateEntityFactory.php" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/src/app/User/Domain/RepositoryInterface/UserRepositoryInterface.php" beforeDir="false" afterPath="$PROJECT_DIR$/src/app/User/Domain/RepositoryInterface/UserRepositoryInterface.php" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/src/app/User/Infrastructure/InfrastructureTest/GenerateTokenServiceTest.php" beforeDir="false" afterPath="$PROJECT_DIR$/src/app/User/Infrastructure/InfrastructureTest/GenerateTokenServiceTest.php" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/src/app/User/Infrastructure/InfrastructureTest/JwtAuthServiceTest.php" beforeDir="false" afterPath="$PROJECT_DIR$/src/app/User/Infrastructure/InfrastructureTest/JwtAuthServiceTest.php" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/src/app/User/Infrastructure/InfrastructureTest/UserRepository_findByIdTest.php" beforeDir="false" afterPath="$PROJECT_DIR$/src/app/User/Infrastructure/InfrastructureTest/UserRepository_findByIdTest.php" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/src/app/User/Infrastructure/InfrastructureTest/UserRepository_updateTest.php" beforeDir="false" afterPath="$PROJECT_DIR$/src/app/User/Infrastructure/InfrastructureTest/UserRepository_updateTest.php" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/src/app/User/Infrastructure/Repository/UserRepository.php" beforeDir="false" afterPath="$PROJECT_DIR$/src/app/User/Infrastructure/Repository/UserRepository.php" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/src/app/User/Presentation/PresentationTest/Controller/UserController_logoutTest.php" beforeDir="false" afterPath="$PROJECT_DIR$/src/app/User/Presentation/PresentationTest/Controller/UserController_logoutTest.php" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/src/app/User/Presentation/PresentationTest/Controller/UserController_registerTest.php" beforeDir="false" afterPath="$PROJECT_DIR$/src/app/User/Presentation/PresentationTest/Controller/UserController_registerTest.php" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/src/app/User/Presentation/PresentationTest/Controller/UserController_showTest.php" beforeDir="false" afterPath="$PROJECT_DIR$/src/app/User/Presentation/PresentationTest/Controller/UserController_showTest.php" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/src/app/User/Presentation/PresentationTest/Controller/UserController_updateTest.php" beforeDir="false" afterPath="$PROJECT_DIR$/src/app/User/Presentation/PresentationTest/Controller/UserController_updateTest.php" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/src/app/User/Presentation/PresentationTest/RegisterUserViewModelFactoryTest.php" beforeDir="false" afterPath="$PROJECT_DIR$/src/app/User/Presentation/PresentationTest/RegisterUserViewModelFactoryTest.php" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/src/app/User/Presentation/PresentationTest/ShowUserViewModelTest.php" beforeDir="false" afterPath="$PROJECT_DIR$/src/app/User/Presentation/PresentationTest/ShowUserViewModelTest.php" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/src/app/User/Presentation/PresentationTest/UpdateUserViewModelTest.php" beforeDir="false" afterPath="$PROJECT_DIR$/src/app/User/Presentation/PresentationTest/UpdateUserViewModelTest.php" afterDir="false" />
     </list>
     <option name="SHOW_DIALOG" value="false" />
     <option name="HIGHLIGHT_CONFLICTS" value="true" />
@@ -200,7 +162,7 @@
     "PHPUnit.メイン.executor": "Run",
     "RunOnceActivity.ShowReadmeOnStart": "true",
     "RunOnceActivity.git.unshallow": "true",
-    "git-widget-placeholder": "feature/create-post-domain-entity",
+    "git-widget-placeholder": "feature/create-post-domain-repository-interface",
     "node.js.detected.package.eslint": "true",
     "node.js.selected.package.eslint": "(autodetect)",
     "nodejs_package_manager_path": "npm",

--- a/src/app/Post/Domain/RepositoryInterface/PostRepositoryInterface.php
+++ b/src/app/Post/Domain/RepositoryInterface/PostRepositoryInterface.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace App\Post\Domain\RepositoryInterface;
+
+use App\Post\Domain\Entity\PostEntity;
+
+interface  PostRepositoryInterface
+{
+    public function save(
+        PostEntity $entity
+    ): ?PostEntity;
+}


### PR DESCRIPTION
### Description

This pull request introduces the `PostRepositoryInterface` within the domain layer.  
It defines the persistence contract for the `PostEntity`, allowing the application to remain decoupled from the infrastructure implementation.

#### Key changes:
- Introduced `PostRepositoryInterface` with a single method: `save(PostEntity $entity): ?PostEntity`
- The interface resides within the domain and strictly works with domain entities

This aligns with the DDD principle of dependency inversion by ensuring that domain logic is not tightly coupled to a specific persistence mechanism.