### PR TITLE
Create posts table migration and Post model with visibility accessor

### DIFF
--- a/.idea/workspace.xml
+++ b/.idea/workspace.xml
@@ -5,7 +5,6 @@
   </component>
   <component name="ChangeListManager">
     <list default="true" id="6952a861-17ec-40ad-b866-c564752c14a8" name="変更" comment="fix: test-environment-fix">
-      <change afterPath="$PROJECT_DIR$/src/app/Post/Domain/RepositoryInterface/PostRepositoryInterface.php" afterDir="false" />
       <change beforePath="$PROJECT_DIR$/.idea/workspace.xml" beforeDir="false" afterPath="$PROJECT_DIR$/.idea/workspace.xml" afterDir="false" />
     </list>
     <option name="SHOW_DIALOG" value="false" />
@@ -162,7 +161,7 @@
     "PHPUnit.メイン.executor": "Run",
     "RunOnceActivity.ShowReadmeOnStart": "true",
     "RunOnceActivity.git.unshallow": "true",
-    "git-widget-placeholder": "feature/create-post-domain-repository-interface",
+    "git-widget-placeholder": "feature/create-post-eloquent__migration",
     "node.js.detected.package.eslint": "true",
     "node.js.selected.package.eslint": "(autodetect)",
     "nodejs_package_manager_path": "npm",

--- a/src/app/Models/Post.php
+++ b/src/app/Models/Post.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Casts\Attribute;
+
+class Post extends Model
+{
+    protected $connection = 'mysql';
+
+    protected $fillable = [
+        'title',
+        'content',
+        'user_id',
+        'visibility',
+    ];
+
+    public function user(): BelongsTo
+    {
+        return $this->belongsTo(User::class, 'user_id');
+    }
+
+    protected function visibility(): Attribute
+    {
+        return Attribute::make(
+            get: fn ($value) => $value === 0 ? 'public' : 'private',
+            set: fn ($value) => $value === 'public' ? 0 : 1,
+        );
+    }
+}

--- a/src/app/Models/User.php
+++ b/src/app/Models/User.php
@@ -29,8 +29,6 @@ class User extends Authenticatable
         'profile_image',
     ];
 
-    protected $connected = 'mysql';
-
     /**
      * The database connection that should be used by the model.
      *

--- a/src/app/Models/User.php
+++ b/src/app/Models/User.php
@@ -6,6 +6,7 @@ namespace App\Models;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Foundation\Auth\User as Authenticatable;
 use Illuminate\Notifications\Notifiable;
+use Illuminate\Database\Eloquent\Relations\HasMany;
 
 class User extends Authenticatable
 {
@@ -27,6 +28,8 @@ class User extends Authenticatable
         'skills',
         'profile_image',
     ];
+
+    protected $connected = 'mysql';
 
     /**
      * The database connection that should be used by the model.
@@ -56,5 +59,10 @@ class User extends Authenticatable
             'password' => 'hashed',
             'skills' => 'array'
         ];
+    }
+
+    public function posts(): hasMany
+    {
+        return $this->hasMany(Post::class);
     }
 }

--- a/src/database/migrations/2025_06_04_094846_create_posts_table.php
+++ b/src/database/migrations/2025_06_04_094846_create_posts_table.php
@@ -1,0 +1,36 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('posts', function (Blueprint $table) {
+            $table->id();
+            $table->text('content');
+            $table->string('media_path')->nullable();
+            $table->unsignedBigInteger('user_id'); // unsignedBigIntegerに修正
+            $table->tinyInteger('visibility')->default(0);
+            $table->timestamps();
+
+            $table->foreign('user_id')
+                ->references('id')
+                ->on('users')
+                ->onDelete('cascade');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('posts');
+    }
+};


### PR DESCRIPTION
### Description
This pull request introduces the migration for the `posts` table and defines the corresponding `Post` Eloquent model. The implementation includes:

- Creation of `posts` table with the following fields:
  - `id`
  - `content`
  - `media_path` (nullable)
  - `user_id` (with foreign key constraint referencing `users.id`)
  - `visibility` as `tinyInteger`, defaulting to `0` (representing "public")
  - Timestamps

- Addition of the `Post` model:
  - `$fillable` includes `title`, `content`, `user_id`, and `visibility`
  - BelongsTo relationship with the `User` model
  - Accessor and mutator for the `visibility` field to convert between `tinyInteger` (DB) and string (`public`/`private`) at the application level
