### PR TITLE
Implement save method for PostRepository with domain-driven persistence

### DIFF
--- a/.idea/workspace.xml
+++ b/.idea/workspace.xml
@@ -5,7 +5,11 @@
   </component>
   <component name="ChangeListManager">
     <list default="true" id="6952a861-17ec-40ad-b866-c564752c14a8" name="変更" comment="fix: test-environment-fix">
+      <change afterPath="$PROJECT_DIR$/src/app/Post/Infrastructure/InfrastructureTest/PostRepositoryTest.php" afterDir="false" />
       <change beforePath="$PROJECT_DIR$/.idea/workspace.xml" beforeDir="false" afterPath="$PROJECT_DIR$/.idea/workspace.xml" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/app/Common/Domain/Enum/PostVisibility.php" beforeDir="false" afterPath="$PROJECT_DIR$/src/app/Common/Domain/Enum/PostVisibility.php" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/app/Models/Post.php" beforeDir="false" afterPath="$PROJECT_DIR$/src/app/Models/Post.php" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/app/Post/Domain/EntityFactory/PostFromModelEntityFactory.php" beforeDir="false" afterPath="$PROJECT_DIR$/src/app/Post/Domain/EntityFactory/PostFromModelEntityFactory.php" afterDir="false" />
     </list>
     <option name="SHOW_DIALOG" value="false" />
     <option name="HIGHLIGHT_CONFLICTS" value="true" />
@@ -161,7 +165,7 @@
     "PHPUnit.メイン.executor": "Run",
     "RunOnceActivity.ShowReadmeOnStart": "true",
     "RunOnceActivity.git.unshallow": "true",
-    "git-widget-placeholder": "feature/create-post-eloquent__migration",
+    "git-widget-placeholder": "feature/create-post-infrastructure-repository",
     "node.js.detected.package.eslint": "true",
     "node.js.selected.package.eslint": "(autodetect)",
     "nodejs_package_manager_path": "npm",
@@ -199,6 +203,21 @@
   <component name="VcsManagerConfiguration">
     <MESSAGE value="fix: test-environment-fix" />
     <option name="LAST_COMMIT_MESSAGE" value="fix: test-environment-fix" />
+  </component>
+  <component name="XDebuggerManager">
+    <breakpoint-manager>
+      <breakpoints>
+        <line-breakpoint enabled="true" type="php-line-method">
+          <url>file://$PROJECT_DIR$/src/app/Post/Domain/Entity/PostEntity.php</url>
+          <line>19</line>
+          <properties>
+            <option name="className" value="\App\Post\Domain\Entity\PostEntity" />
+            <option name="methodName" value="build" />
+          </properties>
+          <option name="timeStamp" value="6" />
+        </line-breakpoint>
+      </breakpoints>
+    </breakpoint-manager>
   </component>
   <component name="XSLT-Support.FileAssociations.UIState">
     <expand />

--- a/src/app/Common/Domain/Enum/PostVisibility.php
+++ b/src/app/Common/Domain/Enum/PostVisibility.php
@@ -17,4 +17,12 @@ enum PostVisibility: string
             default => throw new InvalidArgumentException("Invalid PostVisibility: {$value}"),
         };
     }
+
+    public function toInt(): int
+    {
+        return match ($this) {
+            self::PUBLIC => 1,
+            self::PRIVATE => 2,
+        };
+    }
 }

--- a/src/app/Models/Post.php
+++ b/src/app/Models/Post.php
@@ -5,6 +5,7 @@ namespace App\Models;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Casts\Attribute;
+use App\Common\Domain\Enum\PostVisibility;
 
 class Post extends Model
 {
@@ -14,6 +15,7 @@ class Post extends Model
         'title',
         'content',
         'user_id',
+        'media_path',
         'visibility',
     ];
 

--- a/src/app/Post/Domain/DomainTest/PostFromModelEntityFactoryTest.php
+++ b/src/app/Post/Domain/DomainTest/PostFromModelEntityFactoryTest.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace App\Post\Domain\DomainTest;
+
+use App\Post\Domain\EntityFactory\PostFromModelEntityFactory;
+use Tests\TestCase;
+use App\Post\Domain\Entity\PostEntity;
+
+class PostFromModelEntityFactoryTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+    }
+
+    protected function tearDown(): void
+    {
+        parent::tearDown();
+    }
+
+    private function arrayData(): array
+    {
+        return [
+            'id' => 2,
+            'userId' => 1,
+            'content' => 'yield from eloquent model',
+            'mediaPath' => 'https://example.com/media.jpg',
+            'visibility' => 'public'
+        ];
+    }
+
+    public function test_build_entity_from_factory_successfully_check_type(): void
+    {
+        $result = PostFromModelEntityFactory::build($this->arrayData());
+
+        $this->assertInstanceOf(PostEntity::class, $result);
+    }
+
+    public function test_build_entity_from_factory_successfully_check_data(): void
+    {
+        $result = PostFromModelEntityFactory::build($this->arrayData());
+
+        $this->assertEquals($this->arrayData()['id'], $result->getId()->getValue());
+        $this->assertEquals($this->arrayData()['userId'], $result->getUserId()->getValue());
+        $this->assertEquals($this->arrayData()['content'], $result->getContent());
+        $this->assertEquals($this->arrayData()['mediaPath'], $result->getMediaPath());
+        $this->assertEquals($this->arrayData()['visibility'], $result->getPostVisibility()->getStringValue());
+    }
+}

--- a/src/app/Post/Domain/Entity/PostEntity.php
+++ b/src/app/Post/Domain/Entity/PostEntity.php
@@ -20,11 +20,15 @@ class PostEntity
     public static function build(array $request): self
     {
         return new self(
-            id: isset($request['id']) ? new PostId($request['id']) : null,
-            userId: new UserId($request['userId']),
+            id: isset($request['id'])
+                ? ($request['id'] instanceof PostId ? $request['id'] : new PostId($request['id']))
+                : null,
+            userId: $request['userId'] instanceof UserId ? $request['userId'] : new UserId($request['userId']),
             content: $request['content'],
             mediaPath: $request['mediaPath'] ?? null,
-            visibility: new Postvisibility(PostVisibilityEnum::fromString($request['visibility']))
+            visibility: $request['visibility'] instanceof PostVisibility
+                ? $request['visibility']
+                : new PostVisibility(PostVisibilityEnum::fromString($request['visibility']))
         );
     }
 

--- a/src/app/Post/Domain/EntityFactory/PostFromModelEntityFactory.php
+++ b/src/app/Post/Domain/EntityFactory/PostFromModelEntityFactory.php
@@ -14,12 +14,11 @@ class PostFromModelEntityFactory
     {
         return PostEntity::build([
             'id' => new PostId($request['id']),
-            'userId' => new UserId($request['userId']),
+            'userId' => new UserId($request['user_id']),
             'content' => $request['content'],
-            'mediaPath' => $request['mediaPath'] ?? null,
+            'mediaPath' => $request['media_path'] ?? null,
             'visibility' => new PostVisibility(
-                PostVisibilityEnum::fromString($request['visibility'])
-            ),
+                $request['visibility']),
         ]);
     }
 }

--- a/src/app/Post/Domain/EntityFactory/PostFromModelEntityFactory.php
+++ b/src/app/Post/Domain/EntityFactory/PostFromModelEntityFactory.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace App\Post\Domain\EntityFactory;
+
+use App\Common\Domain\ValueObject\UserId;
+use App\Common\Domain\ValueObject\PostId;
+use App\Post\Domain\ValueObject\Postvisibility;
+use App\Post\Domain\Entity\PostEntity;
+use App\Common\Domain\Enum\PostVisibility as PostVisibilityEnum;
+
+class PostFromModelEntityFactory
+{
+    public static function build(array $request): PostEntity
+    {
+        return PostEntity::build([
+            'id' => new PostId($request['id']),
+            'userId' => new UserId($request['userId']),
+            'content' => $request['content'],
+            'mediaPath' => $request['mediaPath'] ?? null,
+            'visibility' => new PostVisibility(
+                PostVisibilityEnum::fromString($request['visibility'])
+            ),
+        ]);
+    }
+}

--- a/src/app/Post/Infrastructure/InfrastructureTest/PostRepositoryTest.php
+++ b/src/app/Post/Infrastructure/InfrastructureTest/PostRepositoryTest.php
@@ -1,0 +1,107 @@
+<?php
+
+namespace App\Post\Infrastructure\InfrastructureTest;
+
+use App\Post\Domain\Entity\PostEntity;
+use App\Post\Domain\ValueObject\Postvisibility;
+use Tests\TestCase;
+use App\Models\Post;
+use App\Models\User;
+use App\Post\Infrastructure\Repository\PostRepository;
+use Mockery;
+use App\Common\Domain\ValueObject\Userid;
+use App\Common\Domain\ValueObject\PostId;
+use Illuminate\Support\Facades\DB;
+use App\Common\Domain\Enum\PostVisibility as PostVisibilityEnum;
+
+class PostRepositoryTest extends TestCase
+{
+    private $user;
+    private $post;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->refresh();
+        $this->user = new User();
+        $this->post = new Post();
+        $this->repository = new PostRepository(
+            $this->post
+        );
+    }
+
+    protected function tearDown(): void
+    {
+        $this->refresh();
+        parent::tearDown();
+    }
+
+    private function refresh(): void
+    {
+        if (env('APP_ENV') === 'testing') {
+            DB::connection('mysql')->statement('SET FOREIGN_KEY_CHECKS=0;');
+            User::truncate();
+            Post::truncate();
+            DB::connection('mysql')->statement('SET FOREIGN_KEY_CHECKS=1;');
+        }
+    }
+
+    private function arrayUserData(): array
+    {
+        return [
+            'first_name' => 'bruno',
+            'last_name' => 'fernandes',
+            'email' => 'manchester-8@test.com',
+            'password' => 'test1234',
+            'bio' => 'football player',
+            'location' => 'Manchester',
+            'skills' => ['Laravel', 'React'],
+            'profile_image' => 'https://example.com/profile.jpg',
+        ];
+    }
+
+    private function arrayPostData(
+        int $userId
+    ): array
+    {
+        return [
+            'user_id' => $userId,
+            'content' => 'bruno fernandes post content',
+            'media_path' => 'https://example.com/media.jpg',
+            'visibility' => 'public',
+        ];
+    }
+
+    private function mockEntity(int $userId, array $postData): PostEntity
+    {
+        $entity = Mockery::mock(PostEntity::class);
+
+        $entity->shouldReceive('getId')->andReturn(new PostId($this->post->id));
+        $entity->shouldReceive('getUserId')->andReturn(new Userid($userId));
+        $entity->shouldReceive('getContent')->andReturn($postData['content']);
+        $entity->shouldReceive('getMediaPath')->andReturn($postData['media_path']);
+        $entity->shouldReceive('getPostVisibility')->andReturn(
+            new Postvisibility(PostVisibilityEnum::fromString($postData['visibility']))
+        );
+
+        return $entity;
+    }
+
+    public function test_check_value(): void
+    {
+        $user = $this->user->create($this->arrayUserData());
+
+        $postData = $this->arrayPostData($user->id);
+
+        $postEntity = $this->mockEntity($user->id, $postData);
+
+        $this->repository->save($postEntity);
+
+        $this->assertDatabaseHas('posts', [
+            'user_id' => $user->id,
+            'content' => $postData['content'],
+            'media_path' => $postData['media_path'],
+            'visibility' => PostVisibilityEnum::fromString($postData['visibility'])->toInt(),
+        ], 'mysql');
+    }
+}


### PR DESCRIPTION
### 📝 Description

This pull request introduces the implementation of the `save()` method within the `PostRepository` class.  
The method is responsible for persisting a `PostEntity` to the database using the underlying Eloquent `Post` model.

#### Summary of changes:
- Injected `Post` Eloquent model into the repository via constructor.
- Implemented `save(PostEntity $entity): ?PostEntity` method.
- Converted domain value objects into primitive values for persistence.
- Returned the newly created entity using `PostFromModelEntityFactory::build`.
