### PR TITLE
Add Application Layer for Post Creation (UseCommand, DTO, UseCase)

### DIFF
--- a/.idea/workspace.xml
+++ b/.idea/workspace.xml
@@ -5,11 +5,9 @@
   </component>
   <component name="ChangeListManager">
     <list default="true" id="6952a861-17ec-40ad-b866-c564752c14a8" name="変更" comment="fix: test-environment-fix">
-      <change afterPath="$PROJECT_DIR$/src/app/Post/Infrastructure/InfrastructureTest/PostRepositoryTest.php" afterDir="false" />
+      <change afterPath="$PROJECT_DIR$/src/app/Post/Application/ApplicationTest/CreatePostUseCommandTest.php" afterDir="false" />
+      <change afterPath="$PROJECT_DIR$/src/app/Post/Application/UseCommand/CreatePostUseCommand.php" afterDir="false" />
       <change beforePath="$PROJECT_DIR$/.idea/workspace.xml" beforeDir="false" afterPath="$PROJECT_DIR$/.idea/workspace.xml" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/src/app/Common/Domain/Enum/PostVisibility.php" beforeDir="false" afterPath="$PROJECT_DIR$/src/app/Common/Domain/Enum/PostVisibility.php" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/src/app/Models/Post.php" beforeDir="false" afterPath="$PROJECT_DIR$/src/app/Models/Post.php" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/src/app/Post/Domain/EntityFactory/PostFromModelEntityFactory.php" beforeDir="false" afterPath="$PROJECT_DIR$/src/app/Post/Domain/EntityFactory/PostFromModelEntityFactory.php" afterDir="false" />
     </list>
     <option name="SHOW_DIALOG" value="false" />
     <option name="HIGHLIGHT_CONFLICTS" value="true" />
@@ -165,7 +163,7 @@
     "PHPUnit.メイン.executor": "Run",
     "RunOnceActivity.ShowReadmeOnStart": "true",
     "RunOnceActivity.git.unshallow": "true",
-    "git-widget-placeholder": "feature/create-post-infrastructure-repository",
+    "git-widget-placeholder": "feature/create-post-usecommand",
     "node.js.detected.package.eslint": "true",
     "node.js.selected.package.eslint": "(autodetect)",
     "nodejs_package_manager_path": "npm",

--- a/.idea/workspace.xml
+++ b/.idea/workspace.xml
@@ -5,8 +5,8 @@
   </component>
   <component name="ChangeListManager">
     <list default="true" id="6952a861-17ec-40ad-b866-c564752c14a8" name="変更" comment="fix: test-environment-fix">
-      <change afterPath="$PROJECT_DIR$/src/app/Post/Application/ApplicationTest/CreatePostUseCommandTest.php" afterDir="false" />
-      <change afterPath="$PROJECT_DIR$/src/app/Post/Application/UseCommand/CreatePostUseCommand.php" afterDir="false" />
+      <change afterPath="$PROJECT_DIR$/src/app/Post/Application/ApplicationTest/CreatePostDtoTest.php" afterDir="false" />
+      <change afterPath="$PROJECT_DIR$/src/app/Post/Application/Dto/CreatePostDto.php" afterDir="false" />
       <change beforePath="$PROJECT_DIR$/.idea/workspace.xml" beforeDir="false" afterPath="$PROJECT_DIR$/.idea/workspace.xml" afterDir="false" />
     </list>
     <option name="SHOW_DIALOG" value="false" />
@@ -163,7 +163,7 @@
     "PHPUnit.メイン.executor": "Run",
     "RunOnceActivity.ShowReadmeOnStart": "true",
     "RunOnceActivity.git.unshallow": "true",
-    "git-widget-placeholder": "feature/create-post-usecommand",
+    "git-widget-placeholder": "feature/create-post-application-dto",
     "node.js.detected.package.eslint": "true",
     "node.js.selected.package.eslint": "(autodetect)",
     "nodejs_package_manager_path": "npm",
@@ -172,6 +172,7 @@
 }]]></component>
   <component name="RecentsManager">
     <key name="MoveFile.RECENT_KEYS">
+      <recent name="$PROJECT_DIR$/src/app/Post/Application" />
       <recent name="$PROJECT_DIR$/src/app/User/Infrastructure/Service" />
       <recent name="$PROJECT_DIR$/src/app/User/Infrastructure" />
       <recent name="$PROJECT_DIR$/src/app/User/Domain/Service" />

--- a/.idea/workspace.xml
+++ b/.idea/workspace.xml
@@ -5,9 +5,9 @@
   </component>
   <component name="ChangeListManager">
     <list default="true" id="6952a861-17ec-40ad-b866-c564752c14a8" name="変更" comment="fix: test-environment-fix">
-      <change afterPath="$PROJECT_DIR$/src/app/Post/Application/ApplicationTest/CreatePostDtoTest.php" afterDir="false" />
-      <change afterPath="$PROJECT_DIR$/src/app/Post/Application/Dto/CreatePostDto.php" afterDir="false" />
       <change beforePath="$PROJECT_DIR$/.idea/workspace.xml" beforeDir="false" afterPath="$PROJECT_DIR$/.idea/workspace.xml" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/app/Post/Application/Dto/CreatePostDto.php" beforeDir="false" afterPath="$PROJECT_DIR$/src/app/Post/Application/Dto/CreatePostDto.php" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/app/Post/Application/UseCommand/CreatePostUseCommand.php" beforeDir="false" afterPath="$PROJECT_DIR$/src/app/Post/Application/UseCommand/CreatePostUseCommand.php" afterDir="false" />
     </list>
     <option name="SHOW_DIALOG" value="false" />
     <option name="HIGHLIGHT_CONFLICTS" value="true" />
@@ -163,7 +163,7 @@
     "PHPUnit.メイン.executor": "Run",
     "RunOnceActivity.ShowReadmeOnStart": "true",
     "RunOnceActivity.git.unshallow": "true",
-    "git-widget-placeholder": "feature/create-post-application-dto",
+    "git-widget-placeholder": "feature/create-post-application-usecase",
     "node.js.detected.package.eslint": "true",
     "node.js.selected.package.eslint": "(autodetect)",
     "nodejs_package_manager_path": "npm",

--- a/src/app/Post/Application/ApplicationTest/CreatePostDtoTest.php
+++ b/src/app/Post/Application/ApplicationTest/CreatePostDtoTest.php
@@ -1,0 +1,77 @@
+<?php
+
+namespace App\Post\Application\ApplicationTest;
+
+use App\Common\Domain\ValueObject\UserId;
+use App\Post\Domain\ValueObject\Postvisibility;
+use Tests\TestCase;
+use Mockery;
+use App\Post\Domain\Entity\PostEntity;
+use App\Common\Domain\Enum\PostVisibility as PostVisibilityEnum;
+use App\Post\Application\Dto\CreatePostDto;
+
+class CreatePostDtoTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+    }
+
+    protected function tearDown(): void
+    {
+        parent::tearDown();
+    }
+
+    private function mockEntity(): PostEntity
+    {
+        $entity = Mockery::mock(PostEntity::class);
+
+        $entity
+            ->shouldReceive('getUserId')
+            ->andReturn(new UserId(1));
+
+        $entity
+            ->shouldReceive('getContent')
+            ->andReturn($this->arrayData()['content']);
+
+        $entity
+            ->shouldReceive('getMediaPath')
+            ->andReturn($this->arrayData()['mediaPath']);
+
+        $entity
+            ->shouldReceive('getPostVisibility')
+            ->andReturn(new Postvisibility(PostVisibilityEnum::fromString($this->arrayData()['visibility'])));
+
+        return $entity;
+    }
+
+    private function arrayData(): array
+    {
+        return [
+            'userId' => 1,
+            'content' => 'This is a test post content.',
+            'mediaPath' => null,
+            'visibility' => 'public',
+        ];
+    }
+
+    public function test_dto_check_type(): void
+    {
+        $result = new CreatePostDto($this->mockEntity());
+
+        $this->assertInstanceOf(CreatePostDto::class, $result);
+    }
+
+    public function test_dto_check_value(): void
+    {
+        $result = new CreatePostDto($this->mockEntity());
+
+        $this->assertEquals($this->arrayData()['userId'], $result->getUserid()->getValue());
+        $this->assertEquals($this->arrayData()['content'], $result->getContent());
+        $this->assertEquals($this->arrayData()['mediaPath'], $result->getMediaPath());
+        $this->assertEquals(
+            new Postvisibility(PostVisibilityEnum::fromString($this->arrayData()['visibility'])),
+            $result->getVisibility()
+        );
+    }
+}

--- a/src/app/Post/Application/ApplicationTest/CreatePostUseCommandTest.php
+++ b/src/app/Post/Application/ApplicationTest/CreatePostUseCommandTest.php
@@ -1,0 +1,63 @@
+<?php
+
+namespace App\Post\Application\ApplicationTest;
+
+use Tests\TestCase;
+use Mockery;
+use App\Post\Application\UseCommand\CreatePostUseCommand;
+use App\Post\Domain\Entity\PostEntity;
+
+class CreatePostUseCommandTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+    }
+
+    protected function tearDown(): void
+    {
+        parent::tearDown();
+    }
+
+    private function mockEntity(): PostEntity
+    {
+        $entity = Mockery::mock(PostEntity::class);
+
+        $entity
+            ->shouldReceive('getUserId')
+            ->andReturn(1);
+
+        $entity
+            ->shouldReceive('getContent')
+            ->andReturn('This is a test post content.');
+
+        $entity
+            ->shouldReceive('getMediaPath')
+            ->andReturn(null);
+
+        $entity
+            ->shouldReceive('getVisibility')
+            ->andReturn('public');
+
+        return $entity;
+    }
+
+    public function test1_check_type(): void
+    {
+        $result = CreatePostUseCommand::build(
+            $this->arrayData()
+        );
+
+        $this->assertInstanceOf(CreatePostUseCommand::class, $result);
+    }
+
+    private function arrayData(): array
+    {
+        return [
+            'user_id' => 1,
+            'content' => 'This is a test post content.',
+            'media_path' => null,
+            'visibility' => 'public',
+        ];
+    }
+}

--- a/src/app/Post/Application/Dto/CreatePostDto.php
+++ b/src/app/Post/Application/Dto/CreatePostDto.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace App\Post\Application\Dto;
+
+use App\Common\Domain\ValueObject\UserId;
+use App\Post\Domain\Entity\PostEntity;
+use App\Post\Domain\ValueObject\PostVisibility;
+use App\Common\Domain\Enum\PostVisibility as PostVisibilityEnum;
+
+class CreatePostDto
+{
+    public function __construct(
+        public readonly PostEntity $entity,
+    ) {
+    }
+
+    public function getUserid(): UserId
+    {
+        return $this->entity->getUserId();
+    }
+
+    public function getContent(): string
+    {
+        return $this->entity->getContent();
+    }
+
+    public function getMediaPath(): ?string
+    {
+        return $this->entity->getMediaPath();
+    }
+
+    public function getVisibility(): PostVisibility
+    {
+        return $this->entity->getPostVisibility();
+    }
+
+    public function toArray(): array
+    {
+        return [
+            'userId' => $this->getUserid()->getValue(),
+            'content' => $this->getContent(),
+            'mediaPath' => $this->getMediaPath(),
+            'visibility' => $this->getVisibility()->getValue(),
+        ];
+    }
+}

--- a/src/app/Post/Application/Dto/CreatePostDto.php
+++ b/src/app/Post/Application/Dto/CreatePostDto.php
@@ -43,4 +43,9 @@ class CreatePostDto
             'visibility' => $this->getVisibility()->getValue(),
         ];
     }
+
+    public static function build(PostEntity $entity): self
+    {
+        return new self($entity);
+    }
 }

--- a/src/app/Post/Application/UseCommand/CreatePostUseCommand.php
+++ b/src/app/Post/Application/UseCommand/CreatePostUseCommand.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace App\Post\Application\UseCommand;
+
+use InvalidArgumentException;
+
+class CreatePostUseCommand
+{
+    public function __construct(
+        private readonly int $userId,
+        private readonly string $content,
+        private readonly ?string $mediaPath,
+        private readonly string $visibility,
+    ) {
+    }
+
+    private static array $properties = [
+        'user_id',
+        'content',
+        'media_path',
+        'visibility',
+    ];
+
+    public static function build(array $data): self
+    {
+        self::validate($data);
+
+        return new self(
+            userId: $data['user_id'],
+            content: $data['content'],
+            mediaPath: $data['media_path'] ?? null,
+            visibility: $data['visibility'],
+        );
+    }
+
+    private static function validate(array $data): void
+    {
+        foreach (self::$properties as $property) {
+            if ($property === 'media_path') {
+                continue;
+            }
+
+            if (!array_key_exists($property, $data)) {
+                throw new InvalidArgumentException("Missing required property: {$property}");
+            }
+        }
+    }
+}

--- a/src/app/Post/Application/UseCommand/CreatePostUseCommand.php
+++ b/src/app/Post/Application/UseCommand/CreatePostUseCommand.php
@@ -45,4 +45,14 @@ class CreatePostUseCommand
             }
         }
     }
+
+    public function toArray(): array
+    {
+        return [
+            'userId' => $this->userId,
+            'content' => $this->content,
+            'mediaPath' => $this->mediaPath,
+            'visibility' => $this->visibility,
+        ];
+    }
 }

--- a/src/app/Post/Infrastructure/Repository/PostRepository.php
+++ b/src/app/Post/Infrastructure/Repository/PostRepository.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace App\Post\Infrastructure\Repository;
+
+use App\Post\Domain\RepositoryInterface\PostRepositoryInterface;
+use App\Models\Post;
+use App\Post\Domain\Entity\PostEntity;
+use App\Post\Domain\EntityFactory\PostFromModelEntityFactory;
+
+class PostRepository implements PostRepositoryInterface
+{
+    public function __construct(
+        private readonly Post $post
+    ) {}
+
+    public function save(PostEntity $entity): ?PostEntity
+    {
+        $newPost = $this->post->create([
+            'content' => $entity->getContent(),
+            'user_id' => $entity->getUserId()->getValue(),
+            'media_path' => $entity->getMediaPath(),
+            'visibility' => $entity->getPostVisibility()->getValue(),
+        ])->toArray();
+
+        return PostFromModelEntityFactory::build($newPost);
+    }
+}


### PR DESCRIPTION
### Description

This pull request introduces the full implementation of the application layer for the "Post" context, including:

- `CreatePostUseCommand`: Command object to encapsulate the input data and handle internal validation logic.
- `CreatePostDto`: Data transfer object to expose the relevant values of the domain entity after persistence.
- `CreateUseCase`: The application service responsible for orchestrating the creation flow between the command and domain layers.

This completes the application layer structure in line with the project's DDD-based architecture.
