### PR TITLE
Implement create controller method and integration test

### DIFF
--- a/.idea/workspace.xml
+++ b/.idea/workspace.xml
@@ -5,7 +5,12 @@
   </component>
   <component name="ChangeListManager">
     <list default="true" id="6952a861-17ec-40ad-b866-c564752c14a8" name="変更" comment="fix: test-environment-fix">
+      <change afterPath="$PROJECT_DIR$/src/app/Post/Presentation/Controller/PostController.php" afterDir="false" />
+      <change afterPath="$PROJECT_DIR$/src/app/Post/Presentation/PresentationTest/CreatePostViewModelTest.php" afterDir="false" />
+      <change afterPath="$PROJECT_DIR$/src/app/Post/Presentation/ViewModel/CreatePostViewModel.php" afterDir="false" />
       <change beforePath="$PROJECT_DIR$/.idea/workspace.xml" beforeDir="false" afterPath="$PROJECT_DIR$/.idea/workspace.xml" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/app/Common/Domain/Enum/PostVisibility.php" beforeDir="false" afterPath="$PROJECT_DIR$/src/app/Common/Domain/Enum/PostVisibility.php" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/app/Post/Application/Dto/CreatePostDto.php" beforeDir="false" afterPath="$PROJECT_DIR$/src/app/Post/Application/Dto/CreatePostDto.php" afterDir="false" />
     </list>
     <option name="SHOW_DIALOG" value="false" />
     <option name="HIGHLIGHT_CONFLICTS" value="true" />
@@ -156,18 +161,18 @@
     <option name="hideEmptyMiddlePackages" value="true" />
     <option name="showLibraryContents" value="true" />
   </component>
-  <component name="PropertiesComponent"><![CDATA[{
-  "keyToString": {
-    "PHPUnit.メイン.executor": "Run",
-    "RunOnceActivity.ShowReadmeOnStart": "true",
-    "RunOnceActivity.git.unshallow": "true",
-    "git-widget-placeholder": "feature/presentation-create-post-viewmodel",
-    "node.js.detected.package.eslint": "true",
-    "node.js.selected.package.eslint": "(autodetect)",
-    "nodejs_package_manager_path": "npm",
-    "settings.editor.selected.configurable": "Settings.JavaScript"
+  <component name="PropertiesComponent">{
+  &quot;keyToString&quot;: {
+    &quot;PHPUnit.メイン.executor&quot;: &quot;Run&quot;,
+    &quot;RunOnceActivity.ShowReadmeOnStart&quot;: &quot;true&quot;,
+    &quot;RunOnceActivity.git.unshallow&quot;: &quot;true&quot;,
+    &quot;git-widget-placeholder&quot;: &quot;feature/presentation-create-post-viewmodel&quot;,
+    &quot;node.js.detected.package.eslint&quot;: &quot;true&quot;,
+    &quot;node.js.selected.package.eslint&quot;: &quot;(autodetect)&quot;,
+    &quot;nodejs_package_manager_path&quot;: &quot;npm&quot;,
+    &quot;settings.editor.selected.configurable&quot;: &quot;Settings.JavaScript&quot;
   }
-}]]></component>
+}</component>
   <component name="RecentsManager">
     <key name="MoveFile.RECENT_KEYS">
       <recent name="$PROJECT_DIR$/src/app/Post/Application" />

--- a/.idea/workspace.xml
+++ b/.idea/workspace.xml
@@ -6,10 +6,8 @@
   <component name="ChangeListManager">
     <list default="true" id="6952a861-17ec-40ad-b866-c564752c14a8" name="変更" comment="fix: test-environment-fix">
       <change afterPath="$PROJECT_DIR$/src/app/Post/Presentation/Controller/PostController.php" afterDir="false" />
-      <change afterPath="$PROJECT_DIR$/src/app/Post/Presentation/PresentationTest/CreatePostViewModelTest.php" afterDir="false" />
-      <change afterPath="$PROJECT_DIR$/src/app/Post/Presentation/ViewModel/CreatePostViewModel.php" afterDir="false" />
+      <change afterPath="$PROJECT_DIR$/src/app/Post/Presentation/PresentationTest/Controller/PostController_createTest.php" afterDir="false" />
       <change beforePath="$PROJECT_DIR$/.idea/workspace.xml" beforeDir="false" afterPath="$PROJECT_DIR$/.idea/workspace.xml" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/src/app/Common/Domain/Enum/PostVisibility.php" beforeDir="false" afterPath="$PROJECT_DIR$/src/app/Common/Domain/Enum/PostVisibility.php" afterDir="false" />
       <change beforePath="$PROJECT_DIR$/src/app/Post/Application/Dto/CreatePostDto.php" beforeDir="false" afterPath="$PROJECT_DIR$/src/app/Post/Application/Dto/CreatePostDto.php" afterDir="false" />
     </list>
     <option name="SHOW_DIALOG" value="false" />
@@ -161,18 +159,18 @@
     <option name="hideEmptyMiddlePackages" value="true" />
     <option name="showLibraryContents" value="true" />
   </component>
-  <component name="PropertiesComponent">{
-  &quot;keyToString&quot;: {
-    &quot;PHPUnit.メイン.executor&quot;: &quot;Run&quot;,
-    &quot;RunOnceActivity.ShowReadmeOnStart&quot;: &quot;true&quot;,
-    &quot;RunOnceActivity.git.unshallow&quot;: &quot;true&quot;,
-    &quot;git-widget-placeholder&quot;: &quot;feature/presentation-create-post-viewmodel&quot;,
-    &quot;node.js.detected.package.eslint&quot;: &quot;true&quot;,
-    &quot;node.js.selected.package.eslint&quot;: &quot;(autodetect)&quot;,
-    &quot;nodejs_package_manager_path&quot;: &quot;npm&quot;,
-    &quot;settings.editor.selected.configurable&quot;: &quot;Settings.JavaScript&quot;
+  <component name="PropertiesComponent"><![CDATA[{
+  "keyToString": {
+    "PHPUnit.メイン.executor": "Run",
+    "RunOnceActivity.ShowReadmeOnStart": "true",
+    "RunOnceActivity.git.unshallow": "true",
+    "git-widget-placeholder": "feature/create-post-presentation-controller",
+    "node.js.detected.package.eslint": "true",
+    "node.js.selected.package.eslint": "(autodetect)",
+    "nodejs_package_manager_path": "npm",
+    "settings.editor.selected.configurable": "Settings.JavaScript"
   }
-}</component>
+}]]></component>
   <component name="RecentsManager">
     <key name="MoveFile.RECENT_KEYS">
       <recent name="$PROJECT_DIR$/src/app/Post/Application" />

--- a/src/app/Post/Application/Dto/CreatePostDto.php
+++ b/src/app/Post/Application/Dto/CreatePostDto.php
@@ -2,6 +2,7 @@
 
 namespace App\Post\Application\Dto;
 
+use App\Common\Domain\ValueObject\PostId;
 use App\Common\Domain\ValueObject\UserId;
 use App\Post\Domain\Entity\PostEntity;
 use App\Post\Domain\ValueObject\PostVisibility;
@@ -12,6 +13,11 @@ class CreatePostDto
     public function __construct(
         public readonly PostEntity $entity,
     ) {
+    }
+
+    public function getId(): PostId
+    {
+        return $this->entity->getId();
     }
 
     public function getUserid(): UserId

--- a/src/app/Post/Presentation/Controller/PostController.php
+++ b/src/app/Post/Presentation/Controller/PostController.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace App\Post\Presentation\Controller;
+
+use App\Http\Controllers\Controller;
+use App\Post\Application\UseCase\CreateUseCase;
+use App\Post\Presentation\ViewModel\CreatePostViewModel;
+use App\Post\Application\UseCommand\CreatePostUseCommand;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\DB;
+use Throwable;
+
+class PostController extends Controller
+{
+    public function create(
+        Request $request,
+        int $userId,
+        CreateUseCase $useCase
+    ): JsonResponse{
+        DB::connection('mysql')->beginTransaction();
+        try {
+
+            $command = CreatePostUseCommand::build(
+                array_merge(
+                    $request->toArray(),
+                    ['userId' => $userId]
+                )
+            );
+
+            $dto = $useCase->handle($command);
+            $viewModel = new CreatePostViewModel($dto);
+
+            DB::connection('mysql')->commit();
+
+            return response()->json([
+                'status' => 'success',
+                'data' => $viewModel->toArray(),
+            ], 201);
+        } catch (Throwable $e) {
+            DB::connection('mysql')->rollBack();
+            return response()->json([
+                'status' => 'error',
+                'message' => $e->getMessage(),
+            ], 500);
+        }
+    }
+}

--- a/src/app/Post/Presentation/PresentationTest/Controller/PostController_createTest.php
+++ b/src/app/Post/Presentation/PresentationTest/Controller/PostController_createTest.php
@@ -1,0 +1,127 @@
+<?php
+
+namespace App\Post\Presentation\PresentationTest\Controller;
+
+use App\Common\Domain\ValueObject\PostId;
+use App\Common\Domain\ValueObject\UserId;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+use Tests\TestCase;
+use Mockery;
+use App\Post\Application\UseCase\CreateUseCase;
+use App\Post\Application\Dto\CreatePostDto;
+use App\Post\Presentation\ViewModel\CreatePostViewModel;
+use App\Post\Application\UseCommand\CreatePostUseCommand;
+use App\Post\Presentation\Controller\PostController;
+
+class PostController_createTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->controller = new PostController();
+    }
+
+    protected function tearDown(): void
+    {
+        parent::tearDown();
+    }
+
+    private function arrayData(): array
+    {
+        return [
+            'user_id' => 1,
+            'content' => 'Nuno Mendez',
+            'media_path' => 'https://example.com/media.jpg',
+            'visibility' => 'public',
+        ];
+    }
+
+    private function mockUseCommand(): CreatePostUseCommand
+    {
+        $command = Mockery::mock(CreatePostUseCommand::class);
+
+        $command
+            ->shouldReceive('toArray')
+            ->andReturn($this->arrayData());
+
+        return $command;
+    }
+
+    private function mockUseCase(): CreateUseCase
+    {
+        $useCase = Mockery::mock(CreateUseCase::class);
+
+        $useCase
+            ->shouldReceive('handle')
+            ->with($this->mockUseCommand())
+            ->andReturn($this->mockDto());
+
+        return $useCase;
+    }
+
+    private function mockDto(): CreatePostDto
+    {
+        $dto = Mockery::mock(CreatePostDto::class);
+
+        $dto
+            ->shouldReceive('getId')
+            ->andReturn(new PostId(1));
+
+        $dto
+            ->shouldReceive('getUserid')
+            ->andReturn(new UserId($this->arrayData()['user_id']));
+
+        $dto
+            ->shouldReceive('getContent')
+            ->andReturn($this->arrayData()['content']);
+
+        $dto
+            ->shouldReceive('getMediaPath')
+            ->andReturn($this->arrayData()['media_path']);
+
+        $dto
+            ->shouldReceive('getVisibility')
+            ->andReturn($this->arrayData()['visibility']);
+
+        return $dto;
+    }
+
+    private function mockViewModel(): CreatePostViewModel
+    {
+        $dto = $this->mockDto();
+
+        $viewModel = Mockery::mock(CreatePostViewModel::class);
+
+        $viewModel
+            ->shouldReceive('toArray')
+            ->andReturn($dto->toArray());
+
+        return $viewModel;
+    }
+
+    private function mockRequest(): Request
+    {
+        $request = Mockery::mock(Request::class);
+
+        $request
+            ->shouldReceive('all')
+            ->andReturn($this->arrayData());
+
+        return $request;
+    }
+
+    public function test_controller_check_type(): void
+    {
+        $useCase = $this->mockUseCase();
+        $request = $this->mockRequest();
+
+        $response = $this->controller->create(
+            $request,
+            $this->arrayData()['user_id'],
+            $useCase
+        );
+
+        $this->assertInstanceOf(JsonResponse::class, $response);
+    }
+}

--- a/src/app/Post/Presentation/PresentationTest/CreatePostViewModelTest.php
+++ b/src/app/Post/Presentation/PresentationTest/CreatePostViewModelTest.php
@@ -1,0 +1,88 @@
+<?php
+
+namespace App\Post\Presentation\PresentationTest;
+
+use App\Common\Domain\ValueObject\PostId;
+use App\Post\Domain\ValueObject\Postvisibility;
+use Tests\TestCase;
+use App\Post\Application\Dto\CreatePostDto;
+use Mockery;
+use App\Post\Presentation\ViewModel\CreatePostViewModel;
+use App\Common\Domain\ValueObject\UserId;
+use App\Common\Domain\Enum\PostVisibility as PostVisibilityEnum;
+
+class CreatePostViewModelTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+    }
+
+    protected function tearDown(): void
+    {
+        parent::tearDown();
+    }
+
+    private function arrayData(): array
+    {
+        return [
+            'id' => 1,
+            'user_id' => 1,
+            'content' => 'This is a test post',
+            'media_path' => 'https://example.com/media.jpg',
+            'visibility' => 'public',
+        ];
+    }
+
+    private function mockDto(): CreatePostDto
+    {
+        $dto = Mockery::mock(CreatePostDto::class);
+
+        $dto
+            ->shouldReceive('getId')
+            ->andReturn(new PostId($this->arrayData()['id']));
+
+        $dto
+            ->shouldReceive('getUserid')
+            ->andReturn(new UserId($this->arrayData()['user_id']));
+
+        $dto
+            ->shouldReceive('getContent')
+            ->andReturn($this->arrayData()['content']);
+
+        $dto
+            ->shouldReceive('getMediaPath')
+            ->andReturn($this->arrayData()['media_path']);
+
+        $dto
+            ->shouldReceive('getVisibility')
+            ->andReturn(new Postvisibility(PostVisibilityEnum::fromString($this->arrayData()['visibility'])));
+
+        return $dto;
+    }
+
+    public function test1_check_type(): void
+    {
+        $dto = $this->mockDto();
+        $viewModel = new CreatePostViewModel($dto);
+
+        $this->assertInstanceOf(CreatePostViewModel::class, $viewModel);
+    }
+
+    public function test2_check_value(): void
+    {
+        $dto = $this->mockDto();
+        $viewModel = new CreatePostViewModel($dto);
+
+        $result = $viewModel->toArray();
+
+        $this->assertEquals($this->arrayData()['id'], $result['id']);
+        $this->assertEquals($this->arrayData()['user_id'], $result['userId']);
+        $this->assertEquals($this->arrayData()['content'], $result['content']);
+        $this->assertEquals($this->arrayData()['media_path'], $result['mediaPath']);
+        $this->assertEquals(
+            new Postvisibility(PostVisibilityEnum::fromString($this->arrayData()['visibility'])),
+            $dto->getVisibility()
+        );
+    }
+}

--- a/src/app/Post/Presentation/ViewModel/CreatePostViewModel.php
+++ b/src/app/Post/Presentation/ViewModel/CreatePostViewModel.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace App\Post\Presentation\ViewModel;
+
+use App\Post\Application\Dto\CreatePostDto;
+
+class CreatePostViewModel
+{
+    public function __construct(
+        private readonly CreatePostDto $dto,
+    ){}
+
+    public function toArray(): array
+    {
+        return [
+            'id' => $this->dto->getId()->getValue(),
+            'userId' => $this->dto->getUserid()->getValue(),
+            'content' => $this->dto->getContent(),
+            'mediaPath' => $this->dto->getMediaPath(),
+            'visibility' => $this->dto->getVisibility()->getValue()->toLabel(),
+        ];
+    }
+}


### PR DESCRIPTION
### description

This PR introduces the `create` method in the presentation controller, responsible for handling incoming post creation requests.  
The process involves:

- Beginning a DB transaction
- Building a `CreatePostUseCommand` from the incoming request merged with authenticated `userId`
- Executing the use case via `CreateUseCase`
- Wrapping the result in `CreatePostViewModel`
- Committing on success, rolling back on error