### PR TITLE
Refactor: Adjust namespace for UserId Value Object

### DIFF
--- a/.idea/workspace.xml
+++ b/.idea/workspace.xml
@@ -4,7 +4,41 @@
     <option name="autoReloadType" value="SELECTIVE" />
   </component>
   <component name="ChangeListManager">
-    <list default="true" id="6952a861-17ec-40ad-b866-c564752c14a8" name="変更" comment="fix: test-environment-fix" />
+    <list default="true" id="6952a861-17ec-40ad-b866-c564752c14a8" name="変更" comment="fix: test-environment-fix">
+      <change beforePath="$PROJECT_DIR$/.idea/workspace.xml" beforeDir="false" afterPath="$PROJECT_DIR$/.idea/workspace.xml" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/app/User/Application/ApplicationTest/LoginUserDtoTest.php" beforeDir="false" afterPath="$PROJECT_DIR$/src/app/User/Application/ApplicationTest/LoginUserDtoTest.php" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/app/User/Application/ApplicationTest/LogoutUserUseCaseTest.php" beforeDir="false" afterPath="$PROJECT_DIR$/src/app/User/Application/ApplicationTest/LogoutUserUseCaseTest.php" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/app/User/Application/ApplicationTest/RegisterUserDtoFactoryTest.php" beforeDir="false" afterPath="$PROJECT_DIR$/src/app/User/Application/ApplicationTest/RegisterUserDtoFactoryTest.php" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/app/User/Application/ApplicationTest/RegisterUserUseCaseTest.php" beforeDir="false" afterPath="$PROJECT_DIR$/src/app/User/Application/ApplicationTest/RegisterUserUseCaseTest.php" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/app/User/Application/ApplicationTest/ShowUserDtoTest.php" beforeDir="false" afterPath="$PROJECT_DIR$/src/app/User/Application/ApplicationTest/ShowUserDtoTest.php" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/app/User/Application/ApplicationTest/ShowUserUseCaseTest.php" beforeDir="false" afterPath="$PROJECT_DIR$/src/app/User/Application/ApplicationTest/ShowUserUseCaseTest.php" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/app/User/Application/ApplicationTest/UpdateUserDtoTest.php" beforeDir="false" afterPath="$PROJECT_DIR$/src/app/User/Application/ApplicationTest/UpdateUserDtoTest.php" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/app/User/Application/ApplicationTest/UpdateUserUseCaseTest.php" beforeDir="false" afterPath="$PROJECT_DIR$/src/app/User/Application/ApplicationTest/UpdateUserUseCaseTest.php" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/app/User/Application/Dto/LoginUserDto.php" beforeDir="false" afterPath="$PROJECT_DIR$/src/app/User/Application/Dto/LoginUserDto.php" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/app/User/Application/Dto/RegisterUserDto.php" beforeDir="false" afterPath="$PROJECT_DIR$/src/app/User/Application/Dto/RegisterUserDto.php" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/app/User/Application/Dto/ShowUserDto.php" beforeDir="false" afterPath="$PROJECT_DIR$/src/app/User/Application/Dto/ShowUserDto.php" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/app/User/Application/Dto/UpdateUserDto.php" beforeDir="false" afterPath="$PROJECT_DIR$/src/app/User/Application/Dto/UpdateUserDto.php" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/app/User/Application/Factory/RegisterUserDtoFactory.php" beforeDir="false" afterPath="$PROJECT_DIR$/src/app/User/Application/Factory/RegisterUserDtoFactory.php" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/app/User/Application/UseCase/LogoutUserUseCase.php" beforeDir="false" afterPath="$PROJECT_DIR$/src/app/User/Application/UseCase/LogoutUserUseCase.php" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/app/User/Application/UseCase/ShowUserUseCase.php" beforeDir="false" afterPath="$PROJECT_DIR$/src/app/User/Application/UseCase/ShowUserUseCase.php" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/app/User/Domain/Entity/UserEntity.php" beforeDir="false" afterPath="$PROJECT_DIR$/src/app/User/Domain/Entity/UserEntity.php" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/app/User/Domain/Factory/UserEntityFactory.php" beforeDir="false" afterPath="$PROJECT_DIR$/src/app/User/Domain/Factory/UserEntityFactory.php" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/app/User/Domain/Factory/UserFromModelEntityFactory.php" beforeDir="false" afterPath="$PROJECT_DIR$/src/app/User/Domain/Factory/UserFromModelEntityFactory.php" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/app/User/Domain/Factory/UserUpdateEntityFactory.php" beforeDir="false" afterPath="$PROJECT_DIR$/src/app/User/Domain/Factory/UserUpdateEntityFactory.php" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/app/User/Domain/RepositoryInterface/UserRepositoryInterface.php" beforeDir="false" afterPath="$PROJECT_DIR$/src/app/User/Domain/RepositoryInterface/UserRepositoryInterface.php" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/app/User/Infrastructure/InfrastructureTest/GenerateTokenServiceTest.php" beforeDir="false" afterPath="$PROJECT_DIR$/src/app/User/Infrastructure/InfrastructureTest/GenerateTokenServiceTest.php" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/app/User/Infrastructure/InfrastructureTest/JwtAuthServiceTest.php" beforeDir="false" afterPath="$PROJECT_DIR$/src/app/User/Infrastructure/InfrastructureTest/JwtAuthServiceTest.php" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/app/User/Infrastructure/InfrastructureTest/UserRepository_findByIdTest.php" beforeDir="false" afterPath="$PROJECT_DIR$/src/app/User/Infrastructure/InfrastructureTest/UserRepository_findByIdTest.php" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/app/User/Infrastructure/InfrastructureTest/UserRepository_updateTest.php" beforeDir="false" afterPath="$PROJECT_DIR$/src/app/User/Infrastructure/InfrastructureTest/UserRepository_updateTest.php" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/app/User/Infrastructure/Repository/UserRepository.php" beforeDir="false" afterPath="$PROJECT_DIR$/src/app/User/Infrastructure/Repository/UserRepository.php" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/app/User/Presentation/PresentationTest/Controller/UserController_logoutTest.php" beforeDir="false" afterPath="$PROJECT_DIR$/src/app/User/Presentation/PresentationTest/Controller/UserController_logoutTest.php" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/app/User/Presentation/PresentationTest/Controller/UserController_registerTest.php" beforeDir="false" afterPath="$PROJECT_DIR$/src/app/User/Presentation/PresentationTest/Controller/UserController_registerTest.php" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/app/User/Presentation/PresentationTest/Controller/UserController_showTest.php" beforeDir="false" afterPath="$PROJECT_DIR$/src/app/User/Presentation/PresentationTest/Controller/UserController_showTest.php" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/app/User/Presentation/PresentationTest/Controller/UserController_updateTest.php" beforeDir="false" afterPath="$PROJECT_DIR$/src/app/User/Presentation/PresentationTest/Controller/UserController_updateTest.php" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/app/User/Presentation/PresentationTest/RegisterUserViewModelFactoryTest.php" beforeDir="false" afterPath="$PROJECT_DIR$/src/app/User/Presentation/PresentationTest/RegisterUserViewModelFactoryTest.php" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/app/User/Presentation/PresentationTest/ShowUserViewModelTest.php" beforeDir="false" afterPath="$PROJECT_DIR$/src/app/User/Presentation/PresentationTest/ShowUserViewModelTest.php" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/app/User/Presentation/PresentationTest/UpdateUserViewModelTest.php" beforeDir="false" afterPath="$PROJECT_DIR$/src/app/User/Presentation/PresentationTest/UpdateUserViewModelTest.php" afterDir="false" />
+    </list>
     <option name="SHOW_DIALOG" value="false" />
     <option name="HIGHLIGHT_CONFLICTS" value="true" />
     <option name="HIGHLIGHT_NON_ACTIVE_CHANGELIST" value="false" />
@@ -154,18 +188,18 @@
     <option name="hideEmptyMiddlePackages" value="true" />
     <option name="showLibraryContents" value="true" />
   </component>
-  <component name="PropertiesComponent">{
-  &quot;keyToString&quot;: {
-    &quot;PHPUnit.メイン.executor&quot;: &quot;Run&quot;,
-    &quot;RunOnceActivity.ShowReadmeOnStart&quot;: &quot;true&quot;,
-    &quot;RunOnceActivity.git.unshallow&quot;: &quot;true&quot;,
-    &quot;git-widget-placeholder&quot;: &quot;feature/create-post-infrastructure-repository&quot;,
-    &quot;node.js.detected.package.eslint&quot;: &quot;true&quot;,
-    &quot;node.js.selected.package.eslint&quot;: &quot;(autodetect)&quot;,
-    &quot;nodejs_package_manager_path&quot;: &quot;npm&quot;,
-    &quot;settings.editor.selected.configurable&quot;: &quot;Settings.JavaScript&quot;
+  <component name="PropertiesComponent"><![CDATA[{
+  "keyToString": {
+    "PHPUnit.メイン.executor": "Run",
+    "RunOnceActivity.ShowReadmeOnStart": "true",
+    "RunOnceActivity.git.unshallow": "true",
+    "git-widget-placeholder": "feature/modify-namespace-user-id",
+    "node.js.detected.package.eslint": "true",
+    "node.js.selected.package.eslint": "(autodetect)",
+    "nodejs_package_manager_path": "npm",
+    "settings.editor.selected.configurable": "Settings.JavaScript"
   }
-}</component>
+}]]></component>
   <component name="RecentsManager">
     <key name="MoveFile.RECENT_KEYS">
       <recent name="$PROJECT_DIR$/src/app/User/Infrastructure/Service" />

--- a/src/app/User/Application/ApplicationTest/LoginUserDtoTest.php
+++ b/src/app/User/Application/ApplicationTest/LoginUserDtoTest.php
@@ -7,7 +7,7 @@ use App\User\Domain\Entity\UserEntity;
 use App\User\Domain\Factory\UserEntityFactory;
 use App\User\Domain\ValueObject\AuthToken;
 use App\User\Domain\ValueObject\Email;
-use Common\Domain\ValueObjet\UserId;
+use App\Common\Domain\ValueObject\UserId;
 use Mockery;
 use Tests\TestCase;
 

--- a/src/app/User/Application/ApplicationTest/LogoutUserUseCaseTest.php
+++ b/src/app/User/Application/ApplicationTest/LogoutUserUseCaseTest.php
@@ -8,7 +8,7 @@ use App\User\Domain\Factory\UserEntityFactory;
 use App\User\Domain\RepositoryInterface\PasswordHasherInterface;
 use App\User\Domain\RepositoryInterface\UserRepositoryInterface;
 use App\User\Domain\Service\AuthServiceInterface;
-use Common\Domain\ValueObjet\UserId;
+use App\Common\Domain\ValueObject\UserId;
 use Mockery;
 use Tests\TestCase;
 

--- a/src/app/User/Application/ApplicationTest/RegisterUserCommandFactoryTest.php
+++ b/src/app/User/Application/ApplicationTest/RegisterUserCommandFactoryTest.php
@@ -2,7 +2,7 @@
 
 namespace  App\User\Application\ApplicationTest;
 
-use \Illuminate\Http\Request;
+use Illuminate\Http\Request;
 use Tests\TestCase;
 use Mockery;
 use App\User\Application\Factory\RegisterUserCommandFactory;

--- a/src/app/User/Application/ApplicationTest/RegisterUserDtoFactoryTest.php
+++ b/src/app/User/Application/ApplicationTest/RegisterUserDtoFactoryTest.php
@@ -7,7 +7,7 @@ use App\User\Application\Factory\RegisterUserDtoFactory;
 use App\User\Domain\Entity\UserEntity;
 use App\User\Domain\Factory\UserEntityFactory;
 use App\User\Domain\ValueObject\Email;
-use Common\Domain\ValueObjet\UserId;
+use App\Common\Domain\ValueObject\UserId;
 use Mockery;
 use Tests\TestCase;
 

--- a/src/app/User/Application/ApplicationTest/RegisterUserUseCaseTest.php
+++ b/src/app/User/Application/ApplicationTest/RegisterUserUseCaseTest.php
@@ -12,7 +12,7 @@ use App\User\Domain\Factory\UserEntityFactory;
 use App\User\Domain\RepositoryInterface\PasswordHasherInterface;
 use App\User\Domain\ValueObject\Email;
 use App\User\Infrastructure\Repository\UserRepository;
-use Common\Domain\ValueObjet\UserId;
+use App\Common\Domain\ValueObject\UserId;
 use Mockery;
 use Tests\TestCase;
 

--- a/src/app/User/Application/ApplicationTest/ShowUserDtoTest.php
+++ b/src/app/User/Application/ApplicationTest/ShowUserDtoTest.php
@@ -6,7 +6,7 @@ use App\User\Application\Dto\ShowUserDto;
 use App\User\Domain\Entity\UserEntity;
 use App\User\Domain\Factory\UserFromModelEntityFactory;
 use App\User\Domain\ValueObject\Email;
-use Common\Domain\ValueObjet\UserId;
+use App\Common\Domain\ValueObject\UserId;
 use Mockery;
 use Tests\TestCase;
 

--- a/src/app/User/Application/ApplicationTest/ShowUserUseCaseTest.php
+++ b/src/app/User/Application/ApplicationTest/ShowUserUseCaseTest.php
@@ -9,7 +9,7 @@ use App\User\Domain\Entity\UserEntity;
 use App\User\Domain\Factory\UserFromModelEntityFactory;
 use App\User\Domain\RepositoryInterface\UserRepositoryInterface;
 use App\User\Domain\ValueObject\Email;
-use Common\Domain\ValueObjet\UserId;
+use App\Common\Domain\ValueObject\UserId;
 use Mockery;
 use Tests\TestCase;
 

--- a/src/app/User/Application/ApplicationTest/UpdateUserDtoTest.php
+++ b/src/app/User/Application/ApplicationTest/UpdateUserDtoTest.php
@@ -6,7 +6,7 @@ use App\User\Application\Dto\UpdateUserDto;
 use App\User\Domain\Entity\UserEntity;
 use App\User\Domain\Factory\UserUpdateEntityFactory;
 use App\User\Domain\ValueObject\Email;
-use Common\Domain\ValueObjet\UserId;
+use App\Common\Domain\ValueObject\UserId;
 use Mockery;
 use Tests\TestCase;
 

--- a/src/app/User/Application/ApplicationTest/UpdateUserUseCaseTest.php
+++ b/src/app/User/Application/ApplicationTest/UpdateUserUseCaseTest.php
@@ -9,7 +9,7 @@ use App\User\Domain\Factory\UserFromModelEntityFactory;
 use App\User\Domain\Factory\UserUpdateEntityFactory;
 use App\User\Domain\RepositoryInterface\UserRepositoryInterface;
 use App\User\Domain\ValueObject\Email;
-use Common\Domain\ValueObjet\UserId;
+use App\Common\Domain\ValueObject\UserId;
 use Mockery;
 use Tests\TestCase;
 

--- a/src/app/User/Application/Dto/LoginUserDto.php
+++ b/src/app/User/Application/Dto/LoginUserDto.php
@@ -5,7 +5,7 @@ namespace App\User\Application\Dto;
 use App\User\Domain\Entity\UserEntity;
 use App\User\Domain\ValueObject\AuthToken;
 use App\User\Domain\ValueObject\Email;
-use Common\Domain\ValueObjet\UserId;
+use App\Common\Domain\ValueObject\UserId;
 
 class LoginUserDto
 {

--- a/src/app/User/Application/Dto/RegisterUserDto.php
+++ b/src/app/User/Application/Dto/RegisterUserDto.php
@@ -3,7 +3,7 @@
 namespace App\User\Application\Dto;
 
 use App\User\Domain\ValueObject\Email;
-use Common\Domain\ValueObjet\UserId;
+use App\Common\Domain\ValueObject\UserId;
 
 class RegisterUserDto
 {

--- a/src/app/User/Application/Dto/ShowUserDto.php
+++ b/src/app/User/Application/Dto/ShowUserDto.php
@@ -4,7 +4,7 @@ namespace App\User\Application\Dto;
 
 use App\User\Domain\Entity\UserEntity;
 use App\User\Domain\ValueObject\Email;
-use Common\Domain\ValueObjet\UserId;
+use App\Common\Domain\ValueObject\UserId;
 
 class ShowUserDto
 {

--- a/src/app/User/Application/Dto/UpdateUserDto.php
+++ b/src/app/User/Application/Dto/UpdateUserDto.php
@@ -4,7 +4,7 @@ namespace App\User\Application\Dto;
 
 use App\User\Domain\Entity\UserEntity;
 use App\User\Domain\ValueObject\Email;
-use Common\Domain\ValueObjet\UserId;
+use App\Common\Domain\ValueObject\UserId;
 
 class UpdateUserDto
 {

--- a/src/app/User/Application/Factory/RegisterUserDtoFactory.php
+++ b/src/app/User/Application/Factory/RegisterUserDtoFactory.php
@@ -5,7 +5,7 @@ namespace App\User\Application\Factory;
 use App\User\Application\Dto\RegisterUserDto;
 use App\User\Domain\Entity\UserEntity;
 use App\User\Domain\ValueObject\Email;
-use Common\Domain\ValueObjet\UserId;
+use App\Common\Domain\ValueObject\UserId;
 
 class RegisterUserDtoFactory
 {

--- a/src/app/User/Application/UseCase/LogoutUserUseCase.php
+++ b/src/app/User/Application/UseCase/LogoutUserUseCase.php
@@ -4,7 +4,7 @@ namespace App\User\Application\UseCase;
 
 use App\User\Domain\RepositoryInterface\UserRepositoryInterface;
 use App\User\Domain\Service\AuthServiceInterface;
-use Common\Domain\ValueObjet\UserId;
+use App\Common\Domain\ValueObject\UserId;
 
 class LogoutUserUseCase
 {

--- a/src/app/User/Application/UseCase/ShowUserUseCase.php
+++ b/src/app/User/Application/UseCase/ShowUserUseCase.php
@@ -4,7 +4,7 @@ namespace App\User\Application\UseCase;
 
 use App\User\Application\Dto\ShowUserDto;
 use App\User\Domain\RepositoryInterface\UserRepositoryInterface;
-use Common\Domain\ValueObjet\UserId;
+use App\Common\Domain\ValueObject\UserId;
 
 class ShowUserUseCase
 {

--- a/src/app/User/Domain/Entity/UserEntity.php
+++ b/src/app/User/Domain/Entity/UserEntity.php
@@ -4,7 +4,7 @@ namespace App\User\Domain\Entity;
 
 use App\User\Domain\ValueObject\Email;
 use App\User\Domain\ValueObject\Password;
-use Common\Domain\ValueObjet\UserId;
+use App\Common\Domain\ValueObject\UserId;
 use LogicException;
 
 class UserEntity

--- a/src/app/User/Domain/Factory/UserEntityFactory.php
+++ b/src/app/User/Domain/Factory/UserEntityFactory.php
@@ -6,7 +6,7 @@ use App\User\Domain\Entity\UserEntity;
 use App\User\Domain\RepositoryInterface\PasswordHasherInterface;
 use App\User\Domain\ValueObject\Email;
 use App\User\Domain\ValueObject\Password;
-use Common\Domain\ValueObjet\UserId;
+use App\Common\Domain\ValueObject\UserId;
 
 class UserEntityFactory
 {

--- a/src/app/User/Domain/Factory/UserFromModelEntityFactory.php
+++ b/src/app/User/Domain/Factory/UserFromModelEntityFactory.php
@@ -6,7 +6,7 @@ use App\Models\User;
 use App\User\Domain\Entity\UserEntity;
 use App\User\Domain\ValueObject\Email;
 use App\User\Domain\ValueObject\Password;
-use Common\Domain\ValueObjet\UserId;
+use App\Common\Domain\ValueObject\UserId;
 
 class UserFromModelEntityFactory
 {

--- a/src/app/User/Domain/Factory/UserUpdateEntityFactory.php
+++ b/src/app/User/Domain/Factory/UserUpdateEntityFactory.php
@@ -5,7 +5,7 @@ namespace App\User\Domain\Factory;
 use App\User\Application\UseCommand\UpdateUserCommand;
 use App\User\Domain\Entity\UserEntity;
 use App\User\Domain\ValueObject\Email;
-use Common\Domain\ValueObjet\UserId;
+use App\Common\Domain\ValueObject\UserId;
 
 class UserUpdateEntityFactory
 {

--- a/src/app/User/Domain/RepositoryInterface/UserRepositoryInterface.php
+++ b/src/app/User/Domain/RepositoryInterface/UserRepositoryInterface.php
@@ -4,7 +4,7 @@ namespace App\User\Domain\RepositoryInterface;
 
 use App\User\Domain\Entity\UserEntity;
 use App\User\Domain\ValueObject\Email;
-use Common\Domain\ValueObjet\UserId;
+use App\Common\Domain\ValueObject\UserId;
 
 interface UserRepositoryInterface
 {

--- a/src/app/User/Infrastructure/InfrastructureTest/GenerateTokenServiceTest.php
+++ b/src/app/User/Infrastructure/InfrastructureTest/GenerateTokenServiceTest.php
@@ -12,7 +12,7 @@ use App\User\Domain\ValueObject\Email;
 use App\User\Domain\ValueObject\Password;
 use App\User\Infrastructure\Repository\UserRepository;
 use App\User\Infrastructure\Service\GenerateTokenService;
-use Common\Domain\ValueObjet\UserId;
+use App\Common\Domain\ValueObject\UserId;
 use Firebase\JWT\JWT;
 use Firebase\JWT\Key;
 use Illuminate\Support\Facades\DB;

--- a/src/app/User/Infrastructure/InfrastructureTest/JwtAuthServiceTest.php
+++ b/src/app/User/Infrastructure/InfrastructureTest/JwtAuthServiceTest.php
@@ -11,7 +11,7 @@ use App\User\Domain\ValueObject\Email;
 use App\User\Domain\ValueObject\Password;
 use App\User\Infrastructure\Repository\UserRepository;
 use App\User\Infrastructure\Service\JwtAuthService;
-use Common\Domain\ValueObjet\UserId;
+use App\Common\Domain\ValueObject\UserId;
 use Illuminate\Support\Facades\DB;
 use Mockery;
 use Tests\TestCase;

--- a/src/app/User/Infrastructure/InfrastructureTest/UserRepository_findByIdTest.php
+++ b/src/app/User/Infrastructure/InfrastructureTest/UserRepository_findByIdTest.php
@@ -10,7 +10,7 @@ use App\User\Domain\RepositoryInterface\PasswordHasherInterface;
 use App\User\Domain\ValueObject\Email;
 use App\User\Domain\ValueObject\Password;
 use App\User\Infrastructure\Repository\UserRepository;
-use Common\Domain\ValueObjet\UserId;
+use App\Common\Domain\ValueObject\UserId;
 use Illuminate\Support\Facades\DB;
 use Mockery;
 use Tests\TestCase;

--- a/src/app/User/Infrastructure/InfrastructureTest/UserRepository_updateTest.php
+++ b/src/app/User/Infrastructure/InfrastructureTest/UserRepository_updateTest.php
@@ -8,7 +8,7 @@ use App\User\Domain\Factory\UserUpdateEntityFactory;
 use App\User\Domain\RepositoryInterface\PasswordHasherInterface;
 use App\User\Domain\ValueObject\Email;
 use App\User\Infrastructure\Repository\UserRepository;
-use Common\Domain\ValueObjet\UserId;
+use App\Common\Domain\ValueObject\UserId;
 use Illuminate\Support\Facades\DB;
 use Mockery;
 use Tests\TestCase;

--- a/src/app/User/Infrastructure/Repository/UserRepository.php
+++ b/src/app/User/Infrastructure/Repository/UserRepository.php
@@ -8,7 +8,7 @@ use App\User\Domain\Factory\UserFromModelEntityFactory;
 use App\User\Domain\RepositoryInterface\PasswordHasherInterface;
 use App\User\Domain\RepositoryInterface\UserRepositoryInterface;
 use App\User\Domain\ValueObject\Email;
-use Common\Domain\ValueObjet\UserId;
+use App\Common\Domain\ValueObject\UserId;
 use Exception;
 use LogicException;
 

--- a/src/app/User/Presentation/PresentationTest/Controller/UserController_logoutTest.php
+++ b/src/app/User/Presentation/PresentationTest/Controller/UserController_logoutTest.php
@@ -10,7 +10,7 @@ use App\User\Domain\RepositoryInterface\PasswordHasherInterface;
 use App\User\Domain\RepositoryInterface\UserRepositoryInterface;
 use App\User\Domain\Service\AuthServiceInterface;
 use App\User\Presentation\Controller\UserController;
-use Common\Domain\ValueObjet\UserId;
+use App\Common\Domain\ValueObject\UserId;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\DB;
 use Mockery;

--- a/src/app/User/Presentation/PresentationTest/Controller/UserController_registerTest.php
+++ b/src/app/User/Presentation/PresentationTest/Controller/UserController_registerTest.php
@@ -7,7 +7,7 @@ use App\User\Application\UseCase\RegisterUserUsecase;
 use App\User\Application\UseCommand\RegisterUserCommand;
 use App\User\Domain\ValueObject\Email;
 use App\User\Presentation\Controller\UserController;
-use Common\Domain\ValueObjet\UserId;
+use App\Common\Domain\ValueObject\UserId;
 use Illuminate\Http\Request;
 use Mockery;
 use Tests\TestCase;

--- a/src/app/User/Presentation/PresentationTest/Controller/UserController_showTest.php
+++ b/src/app/User/Presentation/PresentationTest/Controller/UserController_showTest.php
@@ -7,7 +7,7 @@ use App\User\Application\UseCase\ShowUserUseCase;
 use App\User\Domain\ValueObject\Email;
 use App\User\Presentation\Controller\UserController;
 use App\User\Presentation\ViewModel\ShowUserViewModel;
-use Common\Domain\ValueObjet\UserId;
+use App\Common\Domain\ValueObject\UserId;
 use Illuminate\Http\JsonResponse;
 use Mockery;
 use Tests\TestCase;

--- a/src/app/User/Presentation/PresentationTest/Controller/UserController_updateTest.php
+++ b/src/app/User/Presentation/PresentationTest/Controller/UserController_updateTest.php
@@ -7,7 +7,7 @@ use App\User\Application\UseCase\UpdateUseCase;
 use App\User\Application\UseCommand\UpdateUserCommand;
 use App\User\Domain\ValueObject\Email;
 use App\User\Presentation\Controller\UserController;
-use Common\Domain\ValueObjet\UserId;
+use App\Common\Domain\ValueObject\UserId;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
 use Mockery;

--- a/src/app/User/Presentation/PresentationTest/RegisterUserViewModelFactoryTest.php
+++ b/src/app/User/Presentation/PresentationTest/RegisterUserViewModelFactoryTest.php
@@ -7,7 +7,7 @@ use App\User\Application\Factory\RegisterUserDtoFactory;
 use App\User\Domain\ValueObject\Email;
 use App\User\Presentation\ViewModel\Factory\RegisterUserViewModelFactory;
 use App\User\Presentation\ViewModel\RegisterUserViewModel;
-use Common\Domain\ValueObjet\UserId;
+use App\Common\Domain\ValueObject\UserId;
 use Mockery;
 use Tests\TestCase;
 

--- a/src/app/User/Presentation/PresentationTest/ShowUserViewModelTest.php
+++ b/src/app/User/Presentation/PresentationTest/ShowUserViewModelTest.php
@@ -5,7 +5,7 @@ namespace App\User\Presentation\PresentationTest;
 use App\User\Application\Dto\ShowUserDto;
 use App\User\Domain\ValueObject\Email;
 use App\User\Presentation\ViewModel\ShowUserViewModel;
-use Common\Domain\ValueObjet\UserId;
+use App\Common\Domain\ValueObject\UserId;
 use Mockery;
 use Tests\TestCase;
 

--- a/src/app/User/Presentation/PresentationTest/UpdateUserViewModelTest.php
+++ b/src/app/User/Presentation/PresentationTest/UpdateUserViewModelTest.php
@@ -5,7 +5,7 @@ namespace App\User\Presentation\PresentationTest;
 use App\User\Application\Dto\UpdateUserDto;
 use App\User\Domain\ValueObject\Email;
 use App\User\Presentation\ViewModel\UpdateUserViewModel;
-use Common\Domain\ValueObjet\UserId;
+use App\Common\Domain\ValueObject\UserId;
 use Mockery;
 use Tests\TestCase;
 


### PR DESCRIPTION
## Description

This pull request updates the namespace of the `UserId` value object to reflect its appropriate domain context.

### Changes
- Moved `UserId` from `App\Common\Domain\ValueObject` to `App\User\Domain\ValueObject`
- Refactored all corresponding `use` statements across:
  - Domain Entities
  - DTOs
  - UseCases
  - Tests
  - ViewModels
- Ensured all affected components now reference the updated namespace and path

This change improves clarity and aligns the Value Object with its bounded context — reflecting that `UserId` is semantically tied to the User domain.
