### PR TITLE
Define GetAllUserPostQueryServiceInterface for retrieving user's post collection

### DIFF
--- a/.idea/workspace.xml
+++ b/.idea/workspace.xml
@@ -5,7 +5,7 @@
   </component>
   <component name="ChangeListManager">
     <list default="true" id="6952a861-17ec-40ad-b866-c564752c14a8" name="変更" comment="fix: test-environment-fix">
-      <change afterPath="$PROJECT_DIR$/src/app/Post/Domain/DomainTest/PostEntityCollectionTest.php" afterDir="false" />
+      <change afterPath="$PROJECT_DIR$/src/app/Post/Application/QueryServiceInterface/GetAllUserPostQueryServiceInterface.php" afterDir="false" />
       <change beforePath="$PROJECT_DIR$/.idea/workspace.xml" beforeDir="false" afterPath="$PROJECT_DIR$/.idea/workspace.xml" afterDir="false" />
     </list>
     <option name="SHOW_DIALOG" value="false" />
@@ -162,7 +162,7 @@
     "PHPUnit.メイン.executor": "Run",
     "RunOnceActivity.ShowReadmeOnStart": "true",
     "RunOnceActivity.git.unshallow": "true",
-    "git-widget-placeholder": "feature/show-post-index-domain-collection",
+    "git-widget-placeholder": "feature/show-post-index-queryservice-interface",
     "node.js.detected.package.eslint": "true",
     "node.js.selected.package.eslint": "(autodetect)",
     "nodejs_package_manager_path": "npm",

--- a/src/app/Post/Application/QueryServiceInterface/GetAllUserPostQueryServiceInterface.php
+++ b/src/app/Post/Application/QueryServiceInterface/GetAllUserPostQueryServiceInterface.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace App\Post\Application\QueryServiceInterface;
+
+use App\Post\Domain\Entity\PostEntityCollection;
+
+interface GetAllUserPostQueryServiceInterface
+{
+    public function getAllUserPosts(
+        int $userId
+    ): PostEntityCollection;
+}


### PR DESCRIPTION
### Description

Introduced a new application-level interface `GetAllUserPostQueryServiceInterface` under the `App\Post\Application\QueryServiceInterface` namespace.

This interface defines the contract for retrieving all posts made by a specific user. It returns a `PostEntityCollection`, encapsulating the list of `PostEntity` objects associated with the user.
