### PR TITLE
Implement PostEntityCollection and define GetAllUserPostQueryServiceInterface

### DIFF
--- a/.idea/workspace.xml
+++ b/.idea/workspace.xml
@@ -5,39 +5,8 @@
   </component>
   <component name="ChangeListManager">
     <list default="true" id="6952a861-17ec-40ad-b866-c564752c14a8" name="変更" comment="fix: test-environment-fix">
+      <change afterPath="$PROJECT_DIR$/src/app/Post/Domain/DomainTest/PostEntityCollectionTest.php" afterDir="false" />
       <change beforePath="$PROJECT_DIR$/.idea/workspace.xml" beforeDir="false" afterPath="$PROJECT_DIR$/.idea/workspace.xml" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/src/app/User/Application/ApplicationTest/LoginUserDtoTest.php" beforeDir="false" afterPath="$PROJECT_DIR$/src/app/User/Application/ApplicationTest/LoginUserDtoTest.php" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/src/app/User/Application/ApplicationTest/LogoutUserUseCaseTest.php" beforeDir="false" afterPath="$PROJECT_DIR$/src/app/User/Application/ApplicationTest/LogoutUserUseCaseTest.php" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/src/app/User/Application/ApplicationTest/RegisterUserDtoFactoryTest.php" beforeDir="false" afterPath="$PROJECT_DIR$/src/app/User/Application/ApplicationTest/RegisterUserDtoFactoryTest.php" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/src/app/User/Application/ApplicationTest/RegisterUserUseCaseTest.php" beforeDir="false" afterPath="$PROJECT_DIR$/src/app/User/Application/ApplicationTest/RegisterUserUseCaseTest.php" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/src/app/User/Application/ApplicationTest/ShowUserDtoTest.php" beforeDir="false" afterPath="$PROJECT_DIR$/src/app/User/Application/ApplicationTest/ShowUserDtoTest.php" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/src/app/User/Application/ApplicationTest/ShowUserUseCaseTest.php" beforeDir="false" afterPath="$PROJECT_DIR$/src/app/User/Application/ApplicationTest/ShowUserUseCaseTest.php" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/src/app/User/Application/ApplicationTest/UpdateUserDtoTest.php" beforeDir="false" afterPath="$PROJECT_DIR$/src/app/User/Application/ApplicationTest/UpdateUserDtoTest.php" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/src/app/User/Application/ApplicationTest/UpdateUserUseCaseTest.php" beforeDir="false" afterPath="$PROJECT_DIR$/src/app/User/Application/ApplicationTest/UpdateUserUseCaseTest.php" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/src/app/User/Application/Dto/LoginUserDto.php" beforeDir="false" afterPath="$PROJECT_DIR$/src/app/User/Application/Dto/LoginUserDto.php" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/src/app/User/Application/Dto/RegisterUserDto.php" beforeDir="false" afterPath="$PROJECT_DIR$/src/app/User/Application/Dto/RegisterUserDto.php" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/src/app/User/Application/Dto/ShowUserDto.php" beforeDir="false" afterPath="$PROJECT_DIR$/src/app/User/Application/Dto/ShowUserDto.php" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/src/app/User/Application/Dto/UpdateUserDto.php" beforeDir="false" afterPath="$PROJECT_DIR$/src/app/User/Application/Dto/UpdateUserDto.php" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/src/app/User/Application/Factory/RegisterUserDtoFactory.php" beforeDir="false" afterPath="$PROJECT_DIR$/src/app/User/Application/Factory/RegisterUserDtoFactory.php" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/src/app/User/Application/UseCase/LogoutUserUseCase.php" beforeDir="false" afterPath="$PROJECT_DIR$/src/app/User/Application/UseCase/LogoutUserUseCase.php" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/src/app/User/Application/UseCase/ShowUserUseCase.php" beforeDir="false" afterPath="$PROJECT_DIR$/src/app/User/Application/UseCase/ShowUserUseCase.php" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/src/app/User/Domain/Entity/UserEntity.php" beforeDir="false" afterPath="$PROJECT_DIR$/src/app/User/Domain/Entity/UserEntity.php" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/src/app/User/Domain/Factory/UserEntityFactory.php" beforeDir="false" afterPath="$PROJECT_DIR$/src/app/User/Domain/Factory/UserEntityFactory.php" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/src/app/User/Domain/Factory/UserFromModelEntityFactory.php" beforeDir="false" afterPath="$PROJECT_DIR$/src/app/User/Domain/Factory/UserFromModelEntityFactory.php" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/src/app/User/Domain/Factory/UserUpdateEntityFactory.php" beforeDir="false" afterPath="$PROJECT_DIR$/src/app/User/Domain/Factory/UserUpdateEntityFactory.php" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/src/app/User/Domain/RepositoryInterface/UserRepositoryInterface.php" beforeDir="false" afterPath="$PROJECT_DIR$/src/app/User/Domain/RepositoryInterface/UserRepositoryInterface.php" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/src/app/User/Infrastructure/InfrastructureTest/GenerateTokenServiceTest.php" beforeDir="false" afterPath="$PROJECT_DIR$/src/app/User/Infrastructure/InfrastructureTest/GenerateTokenServiceTest.php" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/src/app/User/Infrastructure/InfrastructureTest/JwtAuthServiceTest.php" beforeDir="false" afterPath="$PROJECT_DIR$/src/app/User/Infrastructure/InfrastructureTest/JwtAuthServiceTest.php" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/src/app/User/Infrastructure/InfrastructureTest/UserRepository_findByIdTest.php" beforeDir="false" afterPath="$PROJECT_DIR$/src/app/User/Infrastructure/InfrastructureTest/UserRepository_findByIdTest.php" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/src/app/User/Infrastructure/InfrastructureTest/UserRepository_updateTest.php" beforeDir="false" afterPath="$PROJECT_DIR$/src/app/User/Infrastructure/InfrastructureTest/UserRepository_updateTest.php" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/src/app/User/Infrastructure/Repository/UserRepository.php" beforeDir="false" afterPath="$PROJECT_DIR$/src/app/User/Infrastructure/Repository/UserRepository.php" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/src/app/User/Presentation/PresentationTest/Controller/UserController_logoutTest.php" beforeDir="false" afterPath="$PROJECT_DIR$/src/app/User/Presentation/PresentationTest/Controller/UserController_logoutTest.php" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/src/app/User/Presentation/PresentationTest/Controller/UserController_registerTest.php" beforeDir="false" afterPath="$PROJECT_DIR$/src/app/User/Presentation/PresentationTest/Controller/UserController_registerTest.php" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/src/app/User/Presentation/PresentationTest/Controller/UserController_showTest.php" beforeDir="false" afterPath="$PROJECT_DIR$/src/app/User/Presentation/PresentationTest/Controller/UserController_showTest.php" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/src/app/User/Presentation/PresentationTest/Controller/UserController_updateTest.php" beforeDir="false" afterPath="$PROJECT_DIR$/src/app/User/Presentation/PresentationTest/Controller/UserController_updateTest.php" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/src/app/User/Presentation/PresentationTest/RegisterUserViewModelFactoryTest.php" beforeDir="false" afterPath="$PROJECT_DIR$/src/app/User/Presentation/PresentationTest/RegisterUserViewModelFactoryTest.php" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/src/app/User/Presentation/PresentationTest/ShowUserViewModelTest.php" beforeDir="false" afterPath="$PROJECT_DIR$/src/app/User/Presentation/PresentationTest/ShowUserViewModelTest.php" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/src/app/User/Presentation/PresentationTest/UpdateUserViewModelTest.php" beforeDir="false" afterPath="$PROJECT_DIR$/src/app/User/Presentation/PresentationTest/UpdateUserViewModelTest.php" afterDir="false" />
     </list>
     <option name="SHOW_DIALOG" value="false" />
     <option name="HIGHLIGHT_CONFLICTS" value="true" />
@@ -193,7 +162,7 @@
     "PHPUnit.メイン.executor": "Run",
     "RunOnceActivity.ShowReadmeOnStart": "true",
     "RunOnceActivity.git.unshallow": "true",
-    "git-widget-placeholder": "feature/modify-namespace-user-id",
+    "git-widget-placeholder": "feature/show-post-index-domain-collection",
     "node.js.detected.package.eslint": "true",
     "node.js.selected.package.eslint": "(autodetect)",
     "nodejs_package_manager_path": "npm",

--- a/.idea/workspace.xml
+++ b/.idea/workspace.xml
@@ -5,7 +5,7 @@
   </component>
   <component name="ChangeListManager">
     <list default="true" id="6952a861-17ec-40ad-b866-c564752c14a8" name="変更" comment="fix: test-environment-fix">
-      <change afterPath="$PROJECT_DIR$/src/app/Post/Domain/DomainTest/PostEntityCollectionTest.php" afterDir="false" />
+      <change afterPath="$PROJECT_DIR$/src/app/Post/Application/QueryServiceInterface/GetAllUserPostQueryServiceInterface.php" afterDir="false" />
       <change beforePath="$PROJECT_DIR$/.idea/workspace.xml" beforeDir="false" afterPath="$PROJECT_DIR$/.idea/workspace.xml" afterDir="false" />
     </list>
     <option name="SHOW_DIALOG" value="false" />
@@ -162,7 +162,7 @@
     "PHPUnit.メイン.executor": "Run",
     "RunOnceActivity.ShowReadmeOnStart": "true",
     "RunOnceActivity.git.unshallow": "true",
-    "git-widget-placeholder": "feature/show-post-index-domain-collection",
+    "git-widget-placeholder": "feature/show-post-index-queryservice-interface",
     "node.js.detected.package.eslint": "true",
     "node.js.selected.package.eslint": "(autodetect)",
     "nodejs_package_manager_path": "npm",

--- a/src/app/Post/Application/QueryServiceInterface/GetAllUserPostQueryServiceInterface.php
+++ b/src/app/Post/Application/QueryServiceInterface/GetAllUserPostQueryServiceInterface.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace App\Post\Application\QueryServiceInterface;
+
+use App\Post\Domain\Entity\PostEntityCollection;
+
+interface GetAllUserPostQueryServiceInterface
+{
+    public function getAllUserPosts(
+        int $userId
+    ): PostEntityCollection;
+}

--- a/src/app/Post/Domain/DomainTest/PostEntityCollectionTest.php
+++ b/src/app/Post/Domain/DomainTest/PostEntityCollectionTest.php
@@ -1,0 +1,73 @@
+<?php
+
+namespace App\Post\Domain\DomainTest;
+
+use Tests\TestCase;
+use App\Post\Domain\Entity\PostEntity;
+use App\Post\Domain\ValueObject\PostVisibility;
+use App\Common\Domain\ValueObject\PostId;
+use App\Common\Domain\ValueObject\UserId;
+use App\Post\Domain\Entity\PostEntityCollection;
+use App\Common\Domain\Enum\PostVisibility as PostVisibilityEnum;
+
+class PostEntityCollectionTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+    }
+
+    protected function tearDown(): void
+    {
+        parent::tearDown();
+    }
+
+    /**
+     * @return array
+     */
+    public function arrayMultiData(): array
+    {
+        return [
+            0 => [
+                'id' => 1,
+                'userId' => 1,
+                'content' => 'First post content',
+                'mediaPath' => null,
+                'visibility' => 'public',
+            ],
+            1 => [
+                'id' => 2,
+                'userId' => 1,
+                'content' => 'Second post content',
+                'mediaPath' => 'path/to/media.jpg',
+                'visibility' => 'private',
+            ],
+        ];
+    }
+
+    public function test_check_collection_type(): void
+    {
+        $posts = PostEntityCollection::build($this->arrayMultiData());
+
+        $this->assertInstanceOf(PostEntityCollection::class, $posts);
+    }
+
+    public function test_check_collection_value(): void
+    {
+        $posts = PostEntityCollection::build($this->arrayMultiData());
+
+        $this->assertCount(2, $posts->getPosts());
+
+        foreach ($posts->getPosts() as $index => $post) {
+            $this->assertInstanceOf(PostEntity::class, $post);
+            $this->assertEquals(new PostId($this->arrayMultiData()[$index]['id']), $post->getId());
+            $this->assertEquals(new UserId($this->arrayMultiData()[$index]['userId']), $post->getUserId());
+            $this->assertEquals($this->arrayMultiData()[$index]['content'], $post->getContent());
+            $this->assertEquals($this->arrayMultiData()[$index]['mediaPath'], $post->getMediaPath());
+            $this->assertEquals(
+                new PostVisibility(PostVisibilityEnum::fromString($this->arrayMultiData()[$index]['visibility'])),
+                $post->getPostVisibility()
+            );
+        }
+    }
+}

--- a/src/app/Post/Domain/Entity/PostEntityCollection.php
+++ b/src/app/Post/Domain/Entity/PostEntityCollection.php
@@ -1,0 +1,63 @@
+<?php
+
+namespace App\Post\Domain\Entity;
+
+class PostEntityCollection
+{
+    /**
+     * @param PostEntity[] $posts
+     */
+    public function __construct(
+        private array $posts = []
+    ) {}
+
+    /**
+     * Builds a PostEntityCollection from an array of post data.
+     *
+     * @param array<> $posts
+     * @return PostEntityCollection
+     */
+    public static function build(array $posts): self
+    {
+        $postEntities = array_map(
+            fn($post) => PostEntity::build($post),
+            $posts
+        );
+
+        return new self($postEntities);
+    }
+
+    /**
+     * @return array<int, array{id: int|null, userId: int, content: string, mediaPath: string|null, visibility: string}>
+     */
+    public function toArray(): array
+    {
+        return array_map(
+            fn(PostEntity $post) => [
+                'id' => $post->getId()?->getValue(),
+                'userId' => $post->getUserId()->getValue(),
+                'content' => $post->getContent(),
+                'mediaPath' => $post->getMediaPath(),
+                'visibility' => $post->getPostVisibility()->getValue()
+            ],
+            $this->posts
+        );
+    }
+
+    /**
+     * @return PostEntity[]
+     */
+    public function getPosts(): array
+    {
+        return $this->posts;
+    }
+
+
+    /**
+     * @param PostEntity $post
+     */
+    public function addPost(PostEntity $post): void
+    {
+        $this->posts[] = $post;
+    }
+}


### PR DESCRIPTION
### Description

This PR introduces two components to support post aggregation and querying within the domain and application layers:

1. `PostEntityCollection`  
   A dedicated domain object that encapsulates an array of `PostEntity` instances.  
   It provides:
   - `build(array $posts): self`: Factory method from raw data arrays
   - `toArray()`: Converts the collection into an array of associative arrays
   - `getPosts()`: Returns the raw `PostEntity[]`
   - `addPost(PostEntity $post)`: Adds a new post to the collection

2. `GetAllUserPostQueryServiceInterface`  
   An application-layer interface that defines the contract for retrieving all posts made by a specific user, returning a `PostEntityCollection`.
