### PR TITLE
Implement Pagination DTO and factory for application-layer pagination handling

### DIFF
--- a/.idea/workspace.xml
+++ b/.idea/workspace.xml
@@ -5,7 +5,9 @@
   </component>
   <component name="ChangeListManager">
     <list default="true" id="6952a861-17ec-40ad-b866-c564752c14a8" name="変更" comment="fix: test-environment-fix">
-      <change afterPath="$PROJECT_DIR$/src/app/Post/Application/QueryServiceInterface/GetAllUserPostQueryServiceInterface.php" afterDir="false" />
+      <change afterPath="$PROJECT_DIR$/src/app/Common/Application/ApplicationTest/PaginationDtoTest.php" afterDir="false" />
+      <change afterPath="$PROJECT_DIR$/src/app/Common/Application/Dto/Pagination.php" afterDir="false" />
+      <change afterPath="$PROJECT_DIR$/src/app/Common/Application/DtoFactory/PaginationFactory.php" afterDir="false" />
       <change beforePath="$PROJECT_DIR$/.idea/workspace.xml" beforeDir="false" afterPath="$PROJECT_DIR$/.idea/workspace.xml" afterDir="false" />
     </list>
     <option name="SHOW_DIALOG" value="false" />
@@ -162,7 +164,7 @@
     "PHPUnit.メイン.executor": "Run",
     "RunOnceActivity.ShowReadmeOnStart": "true",
     "RunOnceActivity.git.unshallow": "true",
-    "git-widget-placeholder": "feature/show-post-index-queryservice-interface",
+    "git-widget-placeholder": "feature/show-post-index-pagination-dto",
     "node.js.detected.package.eslint": "true",
     "node.js.selected.package.eslint": "(autodetect)",
     "nodejs_package_manager_path": "npm",

--- a/src/app/Common/Application/ApplicationTest/PaginationDtoTest.php
+++ b/src/app/Common/Application/ApplicationTest/PaginationDtoTest.php
@@ -1,0 +1,63 @@
+<?php
+
+namespace App\Common\Application\ApplicationTest;
+
+use Tests\TestCase;
+use App\Common\Application\Dto\Pagination;
+use App\Common\Application\DtoFactory\PaginationFactory;
+
+class PaginationDtoTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+    }
+
+    protected function tearDown(): void
+    {
+        parent::tearDown();
+    }
+
+    private function arrayData(): array
+    {
+        return [
+            'data' => [
+                'id' =>1,
+                'title' => 'Portugal was the winner of the Nations League 2025',
+            ],
+            'current_page' => 2,
+            'from' => 11,
+            'to' => 20,
+            'per_page' => 10,
+            'path' => '/posts',
+            'last_page' => 5,
+            'total' => 50,
+            'first_page_url' => '/posts?page=1',
+            'last_page_url' => '/posts?page=5',
+            'next_page_url' => '/posts?page=3',
+            'prev_page_url' => '/posts?page=1',
+            'links' => [],
+        ];
+    }
+
+
+    public function test_check_pagination_type(): void
+    {
+        $result = PaginationFactory::build($this->arrayData()['data'], $this->arrayData());
+
+        $this->assertInstanceOf(Pagination::class, $result);
+    }
+
+    public function test_check_pagination_values(): void
+    {
+        $result = PaginationFactory::build($this->arrayData()['data'], $this->arrayData());
+
+        foreach ($this->arrayData() as $key => $expectedValue) {
+            if ($key === 'data') {
+                continue;
+            }
+            $getter = 'get' . ucfirst(str_replace('_', '', ucwords($key, '_')));
+            $this->assertEquals($expectedValue, $result->$getter());
+        }
+    }
+}

--- a/src/app/Common/Application/Dto/Pagination.php
+++ b/src/app/Common/Application/Dto/Pagination.php
@@ -1,0 +1,115 @@
+<?php
+
+namespace App\Common\Application\Dto;
+
+use Illuminate\Support\Arr;
+
+class Pagination
+{
+    public function __construct(
+        private array $data,
+        private ?int $currentPage = null,
+        private ?string $from = null,
+        private ?string $to = null,
+        private ?int $perPage = null,
+        private ?string $path = null,
+        private ?int $lastPage = null,
+        private ?int $total = null,
+        private ?string $firstPageUrl = null,
+        private ?string $lastPageUrl = null,
+        private ?string $nextPageUrl = null,
+        private ?string $prevPageUrl = null,
+        private ?array $links = null
+    ) {}
+
+    public function getData(): array
+    {
+        return $this->data;
+    }
+
+    public function getCurrentPage(): ?int
+    {
+        return $this->currentPage;
+    }
+
+    public function getFrom(): ?string
+    {
+        return $this->from;
+    }
+
+    public function getTo(): ?string
+    {
+        return $this->to;
+    }
+
+    public function getPerPage(): ?int
+    {
+        return $this->perPage;
+    }
+
+    public function getPath(): ?string
+    {
+        return $this->path;
+    }
+
+    public function getLastPage(): ?int
+    {
+        return $this->lastPage;
+    }
+
+    public function getTotal(): ?int
+    {
+        return $this->total;
+    }
+
+    public function getFirstPageUrl(): ?string
+    {
+        return $this->firstPageUrl;
+    }
+
+    public function getLastPageUrl(): ?string
+    {
+        return $this->lastPageUrl;
+    }
+
+    public function getNextPageUrl(): ?string
+    {
+        return $this->nextPageUrl;
+    }
+
+    public function getPrevPageUrl(): ?string
+    {
+        return $this->prevPageUrl;
+    }
+
+    public function getLinks(): ?array
+    {
+        return $this->links;
+    }
+
+    public function toArray(): array
+    {
+        $dataArray = Arr::map($this->data, function ($item) {
+            if (is_array($item)) {
+                return $item;
+            }
+            return $item;
+        });
+
+        return [
+            'data' => $dataArray,
+            'current_page' => $this->currentPage,
+            'from' => $this->from,
+            'to' => $this->to,
+            'per_page' => $this->perPage,
+            'path' => $this->path,
+            'last_page' => $this->lastPage,
+            'total' => $this->total,
+            'first_page_url' => $this->firstPageUrl,
+            'last_page_url' => $this->lastPageUrl,
+            'next_page_url' => $this->nextPageUrl,
+            'prev_page_url' => $this->prevPageUrl,
+            'links' => $this->links
+        ];
+    }
+}

--- a/src/app/Common/Application/DtoFactory/PaginationFactory.php
+++ b/src/app/Common/Application/DtoFactory/PaginationFactory.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace App\Common\Application\DtoFactory;
+
+use App\Common\Application\Dto\Pagination;
+use Illuminate\Support\Arr;
+
+class PaginationFactory
+{
+    public static function build(
+        array $data,
+        array $pagination
+    ): Pagination
+    {
+        return new Pagination(
+            $data,
+            self::getValue($pagination, 'current_page'),
+            self::getValue($pagination, 'from'),
+            self::getValue($pagination, 'to'),
+            self::getValue($pagination, 'per_page'),
+            self::getValue($pagination, 'path'),
+            self::getValue($pagination, 'last_page'),
+            self::getValue($pagination, 'total'),
+            self::getValue($pagination, 'first_page_url'),
+            self::getValue($pagination, 'last_page_url'),
+            self::getValue($pagination, 'next_page_url'),
+            self::getValue($pagination, 'prev_page_url'),
+            self::getValue($pagination, 'links')
+        );
+    }
+
+    private static function getValue(array $array, string $key): mixed
+    {
+        return Arr::get($array, $key, null);
+    }
+}


### PR DESCRIPTION
### Description

This PR introduces a reusable pagination structure at the application layer, composed of the following:

- `Pagination` DTO  
  A data container that encapsulates paginated result data and relevant metadata such as `currentPage`, `total`, `perPage`, `links`, etc.  
  It exposes:
  - Public getters for all pagination attributes
  - A `toArray()` method that converts the DTO into a standard response structure, suitable for JSON API output

- `PaginationFactory`  
  A factory class responsible for constructing `Pagination` instances from raw data arrays.  
  It safely extracts values using Laravel's `Arr::get` and encapsulates the pagination structure centrally.
