### PR TITLE
Implement Pagination ViewModel and factory for presentation-layer formatting

### DIFF
--- a/.idea/workspace.xml
+++ b/.idea/workspace.xml
@@ -5,9 +5,9 @@
   </component>
   <component name="ChangeListManager">
     <list default="true" id="6952a861-17ec-40ad-b866-c564752c14a8" name="変更" comment="fix: test-environment-fix">
-      <change afterPath="$PROJECT_DIR$/src/app/Common/Application/ApplicationTest/PaginationDtoTest.php" afterDir="false" />
-      <change afterPath="$PROJECT_DIR$/src/app/Common/Application/Dto/Pagination.php" afterDir="false" />
-      <change afterPath="$PROJECT_DIR$/src/app/Common/Application/DtoFactory/PaginationFactory.php" afterDir="false" />
+      <change afterPath="$PROJECT_DIR$/src/app/Common/Presentation/PresentationTest/PaginationViewModelTest.php" afterDir="false" />
+      <change afterPath="$PROJECT_DIR$/src/app/Common/Presentation/ViewModel/Pagination.php" afterDir="false" />
+      <change afterPath="$PROJECT_DIR$/src/app/Common/Presentation/ViewModelFactory/PaginationFactory.php" afterDir="false" />
       <change beforePath="$PROJECT_DIR$/.idea/workspace.xml" beforeDir="false" afterPath="$PROJECT_DIR$/.idea/workspace.xml" afterDir="false" />
     </list>
     <option name="SHOW_DIALOG" value="false" />
@@ -164,7 +164,7 @@
     "PHPUnit.メイン.executor": "Run",
     "RunOnceActivity.ShowReadmeOnStart": "true",
     "RunOnceActivity.git.unshallow": "true",
-    "git-widget-placeholder": "feature/show-post-index-pagination-dto",
+    "git-widget-placeholder": "feature/show-post-index-pagination-viewmodel",
     "node.js.detected.package.eslint": "true",
     "node.js.selected.package.eslint": "(autodetect)",
     "nodejs_package_manager_path": "npm",

--- a/src/app/Common/Presentation/PresentationTest/PaginationViewModelTest.php
+++ b/src/app/Common/Presentation/PresentationTest/PaginationViewModelTest.php
@@ -1,0 +1,132 @@
+<?php
+
+namespace App\Common\Presentation\PresentationTest;
+
+use Tests\TestCase;
+use Mockery;
+use App\Common\Presentation\ViewModel\Pagination;
+use App\Common\Application\Dto\Pagination as PaginationDto;
+use App\Common\Presentation\ViewModelFactory\PaginationFactory as PaginationViewModelFactory;
+use App\Common\Application\DtoFactory\PaginationFactory as PaginationDtoFactory;
+
+class PaginationViewModelTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+    }
+
+    protected function tearDown(): void
+    {
+        parent::tearDown();
+    }
+
+    private function mockDto(): PaginationDto
+    {
+        $factory = Mockery::mock(
+            'alias:' . PaginationDtoFactory::class
+        );
+
+        $dto = Mockery::mock(PaginationDto::class);
+
+        $factory
+            ->shouldReceive('build')
+            ->andReturn($dto);
+
+        $dto
+            ->shouldReceive('getCurrentPage')
+            ->andReturn(1);
+
+        $dto
+            ->shouldReceive('getPerPage')
+            ->andReturn(10);
+
+        $dto
+            ->shouldReceive('getTotal')
+            ->andReturn(100);
+
+        $dto
+            ->shouldReceive('getLastPage')
+            ->andReturn(10);
+
+        $dto
+            ->shouldReceive('getFrom')
+            ->andReturn(1);
+
+        $dto
+            ->shouldReceive('getTo')
+            ->andReturn(10);
+
+        $dto
+            ->shouldReceive('getPath')
+            ->andReturn('/api/items');
+
+        $dto
+            ->shouldReceive('getFirstPageUrl')
+            ->andReturn('/api/items?page=1');
+
+        $dto
+            ->shouldReceive('getLastPageUrl')
+            ->andReturn('/api/items?page=10');
+
+        $dto
+            ->shouldReceive('getNextPageUrl')
+            ->andReturn('/api/items?page=2');
+
+        $dto
+            ->shouldReceive('getPrevPageUrl')
+            ->andReturn(null);
+
+        $dto
+            ->shouldReceive('getLinks')
+            ->andReturn([]);
+
+        return $dto;
+    }
+
+    private function arrayData(): array
+    {
+        return [
+            'data' => [
+                'id' => 1,
+                'name' => 'Cristiano Ronaldo',
+            ],
+            'current_page' => 1,
+            'from' => 1,
+            'to' => 10,
+            'per_page' => 10,
+            'path' => '/api/items',
+            'last_page' => 10,
+            'total' => 100,
+            'first_page_url' => '/api/items?page=1',
+            'last_page_url' => '/api/items?page=10',
+            'next_page_url' => '/api/items?page=2',
+            'prev_page_url' => null,
+        ];
+    }
+
+    public function test_check_viewModel_type(): void
+    {
+        $dto = $this->mockDto();
+        $viewModel = PaginationViewModelFactory::build($dto, $this->arrayData());
+
+        $this->assertInstanceOf(Pagination::class, $viewModel);
+    }
+
+    public function test_check_viewModel_value(): void
+    {
+        $dto = $this->mockDto();
+        $viewModel = PaginationViewModelFactory::build($dto, $this->arrayData());
+
+        $this->assertInstanceOf(Pagination::class, $viewModel);
+
+       foreach ($this->arrayData() as $key => $expectedValue) {
+            $camelKey = lcfirst(str_replace('_', '', ucwords($key, '_')));
+            $getter = 'get' . ucfirst($camelKey);
+
+            if (method_exists($viewModel, $getter)) {
+                $this->assertEquals($expectedValue, $viewModel->$getter());
+            }
+        }
+    }
+}

--- a/src/app/Common/Presentation/ViewModel/Pagination.php
+++ b/src/app/Common/Presentation/ViewModel/Pagination.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace App\Common\Presentation\ViewModel;
+
+use App\Common\Application\Dto\Pagination as PaginationDto;
+
+class Pagination
+{
+    public function __construct(
+        private array $data,
+        private int $currentPage,
+        private int $from,
+        private int $to,
+        private int $perPage,
+        private string $path,
+        private int $lastPage,
+        private int $total,
+        private string $firstPageUrl,
+        private string $lastPageUrl,
+        private ?string $nextPageUrl = null,
+        private ?string $prevPageUrl = null,
+        private array $links = []
+    ) {}
+
+    public function toArray(): array
+    {
+        return array_merge(
+            [
+                'data' => $this->data
+            ],
+            [
+                'currentPage' => $this->currentPage,
+                'from' => $this->from,
+                'to' => $this->to,
+                'perPage' => $this->perPage,
+                'path' => $this->path,
+                'lastPage' => $this->lastPage,
+                'total' => $this->total,
+                'firstPageUrl' => $this->firstPageUrl,
+                'lastPageUrl' => $this->lastPageUrl,
+                'nextPageUrl' => $this->nextPageUrl,
+                'prevPageUrl' => $this->prevPageUrl,
+                'links' => $this->links
+            ]
+        );
+    }
+}

--- a/src/app/Common/Presentation/ViewModelFactory/PaginationFactory.php
+++ b/src/app/Common/Presentation/ViewModelFactory/PaginationFactory.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace App\Common\Presentation\ViewModelFactory;
+
+use App\Common\Application\Dto\Pagination as PaginationDto;
+use App\Common\Presentation\ViewModel\Pagination;
+
+class PaginationFactory
+{
+    public static function build(
+        PaginationDto $dto,
+        array $data
+    ): Pagination
+    {
+        return new Pagination(
+            $data,
+            $dto->getCurrentPage(),
+            $dto->getFrom(),
+            $dto->getTo(),
+            $dto->getPerPage(),
+            $dto->getPath(),
+            $dto->getLastPage(),
+            $dto->getTotal(),
+            $dto->getFirstPageUrl(),
+            $dto->getLastPageUrl(),
+            $dto->getNextPageUrl(),
+            $dto->getPrevPageUrl(),
+            $dto->getLinks()
+        );
+    }
+}


### PR DESCRIPTION
### Description

This PR introduces the following presentation-layer components for consistent pagination response formatting:

1. `Pagination` ViewModel  
   A dedicated class responsible for shaping the API response structure of paginated data. It encapsulates both the paginated dataset (`data`) and metadata such as `currentPage`, `perPage`, `total`, `links`, etc.  
   It exposes a `toArray()` method that merges all data into a standard API-ready array format.

2. `PaginationFactory` (ViewModelFactory)  
   Responsible for transforming a `PaginationDto` from the application layer into a `Pagination` ViewModel.  
   It bridges between the application-layer DTO and the response-ready ViewModel.
