### PR TITLE
Add use case for retrieving all user posts with pagination

### DIFF
--- a/.idea/workspace.xml
+++ b/.idea/workspace.xml
@@ -5,10 +5,8 @@
   </component>
   <component name="ChangeListManager">
     <list default="true" id="6952a861-17ec-40ad-b866-c564752c14a8" name="変更" comment="">
-      <change afterPath="$PROJECT_DIR$/src/app/Post/Application/ApplicationTest/GetAllUserPostDtoCollectionTest.php" afterDir="false" />
-      <change afterPath="$PROJECT_DIR$/src/app/Post/Application/ApplicationTest/GetAllUserPostDtoTest.php" afterDir="false" />
-      <change afterPath="$PROJECT_DIR$/src/app/Post/Application/Dto/GetAllUserPostDto.php" afterDir="false" />
-      <change afterPath="$PROJECT_DIR$/src/app/Post/Application/Dto/GetAllUserPostDtoCollection.php" afterDir="false" />
+      <change afterPath="$PROJECT_DIR$/src/app/Post/Application/ApplicationTest/GetAllUserPostUseCaseTest.php" afterDir="false" />
+      <change afterPath="$PROJECT_DIR$/src/app/Post/Application/UseCase/GetAllUserPostUseCase.php" afterDir="false" />
       <change beforePath="$PROJECT_DIR$/.idea/workspace.xml" beforeDir="false" afterPath="$PROJECT_DIR$/.idea/workspace.xml" afterDir="false" />
     </list>
     <option name="SHOW_DIALOG" value="false" />
@@ -165,7 +163,7 @@
     "PHPUnit.メイン.executor": "Run",
     "RunOnceActivity.ShowReadmeOnStart": "true",
     "RunOnceActivity.git.unshallow": "true",
-    "git-widget-placeholder": "feautre/show-post-index-application-dto",
+    "git-widget-placeholder": "feature/show-post-index-application-usecase",
     "node.js.detected.package.eslint": "true",
     "node.js.selected.package.eslint": "(autodetect)",
     "nodejs_package_manager_path": "npm",

--- a/src/app/Post/Application/ApplicationTest/GetAllUserPostUseCaseTest.php
+++ b/src/app/Post/Application/ApplicationTest/GetAllUserPostUseCaseTest.php
@@ -1,0 +1,130 @@
+<?php
+
+namespace App\Post\Application\ApplicationTest;
+
+use App\Common\Domain\ValueObject\UserId;
+use App\Post\Application\QueryServiceInterface\GetAllUserPostQueryServiceInterface;
+use Tests\TestCase;
+use Mockery;
+use App\Post\Application\Dto\GetAllUserPostDto;
+use App\Post\Application\Dto\GetAllUserPostDtoCollection;
+use App\Common\Application\Dto\Pagination;
+use App\Common\Domain\ValueObject\PostId;
+use App\Post\Application\UseCase\GetAllUserPostUseCase;
+
+class GetAllUserPostUseCaseTest extends TestCase
+{
+    private $userId;
+    protected function setUp(): void
+    {
+        parent::setUp();
+    }
+
+    protected function tearDown(): void
+    {
+        parent::tearDown();
+    }
+
+    private function arrayRequestData(): array
+    {
+        return [
+            [
+                'id' => 1,
+                'userId' => $this->userId,
+                'content' => 'Sample post content',
+                'mediaPath' => 'path/to/media.jpg',
+                'visibility' => 'public',
+            ],
+            [
+                'id' => 2,
+                'userId' => $this->userId,
+                'content' => 'Another post content',
+                'mediaPath' => 'path/to/another_media.jpg',
+                'visibility' => 'private',
+            ],
+        ];
+    }
+
+    private function mockQueryService(): GetAllUserPostQueryServiceInterface
+    {
+        $mock = Mockery::mock(GetAllUserPostQueryServiceInterface::class);
+
+        $mock->shouldReceive('getAllUserPosts')
+            ->with(
+                Mockery::on('is_int'),
+                Mockery::on('is_int'),
+                Mockery::on('is_int')
+            )
+            ->andReturn($this->mockPagination());
+
+        return $mock;
+    }
+
+    private function mockPagination(): Pagination
+    {
+        $mock = Mockery::mock(Pagination::class);
+
+        $mock->shouldReceive('getCurrentPage')
+            ->andReturn(1);
+
+        $mock->shouldReceive('getPerPage')
+            ->andReturn(10);
+
+        $mock->shouldReceive('getTotal')
+            ->andReturn(2);
+
+        $mock->shouldReceive('getItems')
+            ->andReturn($this->mockDtoCollection()->getPosts());
+
+        return $mock;
+    }
+
+    private function mockDtoCollection(): GetAllUserPostDtoCollection
+    {
+        $mock = Mockery::mock(GetAllUserPostDtoCollection::class);
+
+        $mock->shouldReceive('getPosts')
+            ->andReturn(array_map(function ($data) {
+                return $this->mockDto();
+            }, $this->arrayRequestData()));
+
+        return $mock;
+    }
+
+    private function mockDto(): GetAllUserPostDto
+    {
+        $mock = Mockery::mock(GetAllUserPostDto::class);
+
+        $mock->shouldReceive('getId')
+            ->andReturn(new PostId($this->arrayRequestData()[0]['id']));
+
+        $mock->shouldReceive('getUserId')
+            ->andReturn(new UserId($this->arrayRequestData()[0]['userId']));
+
+        $mock->shouldReceive('getContent')
+            ->andReturn($this->arrayRequestData()[0]['content']);
+
+        $mock->shouldReceive('getMediaPath')
+            ->andReturn($this->arrayRequestData()[0]['mediaPath']);
+
+        $mock->shouldReceive('getPostVisibility')
+            ->andReturn($this->arrayRequestData()[0]['visibility']);
+
+        return $mock;
+    }
+
+    public function test_use_case_check(): void
+    {
+        $queryService = $this->mockQueryService();
+
+        $useCase = new GetAllUserPostUseCase($queryService);
+
+        $result = $useCase->handle(
+            $this->arrayRequestData()[0]['id'],
+            1,
+            10
+        );
+
+        $this->assertInstanceOf(Pagination::class, $result);
+    }
+}

--- a/src/app/Post/Application/UseCase/GetAllUserPostUseCase.php
+++ b/src/app/Post/Application/UseCase/GetAllUserPostUseCase.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace App\Post\Application\UseCase;
+
+use App\Common\Domain\ValueObject\UserId;
+use App\Common\Application\Dto\Pagination;
+use App\Post\Application\QueryServiceInterface\GetAllUserPostQueryServiceInterface;
+
+class GetAllUserPostUseCase
+{
+    public function __construct(
+        private readonly GetAllUserPostQueryServiceInterface $queryService
+    ) {}
+
+    public function handle(
+        int $userId,
+        int $perPage,
+        int $currentPage
+    ): Pagination
+    {
+        return $this->queryService->getAllUserPosts(
+            $userId,
+            $perPage,
+            $currentPage
+        );
+    }
+}


### PR DESCRIPTION
### Description

This pull request introduces the `GetAllUserPostUseCase` class to the application layer.  
Its primary function is to retrieve all posts associated with a given user ID, using the `GetAllUserPostQueryServiceInterface`, and return them as a paginated result.

#### Details:
- Introduced `GetAllUserPostUseCase` with method `handle(int $userId, int $perPage, int $currentPage): Pagination`
- Delegates actual data retrieval to the query service
- Keeps application logic clean and focused on orchestration