### PR TITLE
Implement GetAllUserPostViewModel and its test

### DIFF
--- a/.idea/workspace.xml
+++ b/.idea/workspace.xml
@@ -5,8 +5,8 @@
   </component>
   <component name="ChangeListManager">
     <list default="true" id="6952a861-17ec-40ad-b866-c564752c14a8" name="変更" comment="">
-      <change afterPath="$PROJECT_DIR$/src/app/Post/Application/ApplicationTest/GetAllUserPostUseCaseTest.php" afterDir="false" />
-      <change afterPath="$PROJECT_DIR$/src/app/Post/Application/UseCase/GetAllUserPostUseCase.php" afterDir="false" />
+      <change afterPath="$PROJECT_DIR$/src/app/Post/Presentation/PresentationTest/GetAllUserPostViewModelTest.php" afterDir="false" />
+      <change afterPath="$PROJECT_DIR$/src/app/Post/Presentation/ViewModel/GetAllUserPostViewModel.php" afterDir="false" />
       <change beforePath="$PROJECT_DIR$/.idea/workspace.xml" beforeDir="false" afterPath="$PROJECT_DIR$/.idea/workspace.xml" afterDir="false" />
     </list>
     <option name="SHOW_DIALOG" value="false" />
@@ -163,7 +163,7 @@
     "PHPUnit.メイン.executor": "Run",
     "RunOnceActivity.ShowReadmeOnStart": "true",
     "RunOnceActivity.git.unshallow": "true",
-    "git-widget-placeholder": "feature/show-post-index-application-usecase",
+    "git-widget-placeholder": "feature/show-post-index-presentation-viewmodel",
     "node.js.detected.package.eslint": "true",
     "node.js.selected.package.eslint": "(autodetect)",
     "nodejs_package_manager_path": "npm",

--- a/src/app/Post/Presentation/PresentationTest/GetAllUserPostViewModelTest.php
+++ b/src/app/Post/Presentation/PresentationTest/GetAllUserPostViewModelTest.php
@@ -1,0 +1,76 @@
+<?php
+
+namespace App\Post\Presentation\PresentationTest;
+
+use App\Post\Presentation\ViewModel\GetAllUserPostViewModel;
+use Tests\TestCase;
+use App\Post\Application\Dto\GetAllUserPostDto;
+use Mockery;
+
+class GetAllUserPostViewModelTest extends TestCase
+{
+    private int $userId;
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->userId = 1;
+    }
+
+    protected function tearDown(): void
+    {
+        parent::tearDown();
+    }
+
+    private function arrayMultiData(): array
+    {
+        return [
+            [
+                'id' => 1,
+                'userId' => $this->userId,
+                'content' => 'Sample post content',
+                'mediaPath' => 'path/to/media.jpg',
+                'visibility' => 'public',
+            ],
+            [
+                'id' => 2,
+                'userId' => $this->userId,
+                'content' => 'Another post content',
+                'mediaPath' => 'path/to/another_media.jpg',
+                'visibility' => 'private',
+            ],
+        ];
+    }
+
+    private function mockDto(): GetAllUserPostDto
+    {
+        $mock = Mockery::mock(GetAllUserPostDto::class);
+
+        $mock
+            ->shouldReceive('toArray')
+            ->andReturn($this->arrayMultiData()[0]);
+
+        return $mock;
+    }
+
+    public function test_view_model_check_type(): void
+    {
+        $result = GetAllUserPostViewModel::build(
+            $this->mockDto()
+        );
+
+        $this->assertInstanceOf(GetAllUserPostViewModel::class, $result);
+    }
+
+    public function test_view_model_check_value(): void
+    {
+        $result = GetAllUserPostViewModel::build(
+            $this->mockDto()
+        );
+
+        $this->assertSame($this->arrayMultiData()[0]['id'], $result->toArray()['id']);
+        $this->assertSame($this->arrayMultiData()[0]['userId'], $result->toArray()['userId']);
+        $this->assertSame($this->arrayMultiData()[0]['content'], $result->toArray()['content']);
+        $this->assertSame($this->arrayMultiData()[0]['mediaPath'], $result->toArray()['mediaPath']);
+        $this->assertSame($this->arrayMultiData()[0]['visibility'], $result->toArray()['visibility']);
+    }
+}

--- a/src/app/Post/Presentation/ViewModel/GetAllUserPostViewModel.php
+++ b/src/app/Post/Presentation/ViewModel/GetAllUserPostViewModel.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace App\Post\Presentation\ViewModel;
+
+use App\Post\Application\Dto\GetAllUserPostDto;
+
+class GetAllUserPostViewModel
+{
+    public function __construct(
+        private int $id,
+        private int $userId,
+        private string $content,
+        private ?string $mediaPath,
+        private string $visibility
+    ) {}
+
+    public static function build(GetAllUserPostDto $data): self
+    {
+        $dtoArray = $data->toArray();
+        return new self(
+            id: $dtoArray['id'],
+            userId: $dtoArray['userId'],
+            content: $dtoArray['content'],
+            mediaPath: $dtoArray['mediaPath'] ?? null,
+            visibility: $dtoArray['visibility']
+        );
+    }
+
+    public function toArray(): array
+    {
+        return [
+            'id' => $this->id,
+            'userId' => $this->userId,
+            'content' => $this->content,
+            'mediaPath' => $this->mediaPath,
+            'visibility' => $this->visibility
+        ];
+    }
+}


### PR DESCRIPTION
## Description

This pull request introduces the `GetAllUserPostViewModel` which acts as a presenter for the `GetAllUserPostDto`. It transforms the application-layer DTO into a structured, presentation-friendly object suitable for the response layer.

The following changes are included:

- Created `GetAllUserPostViewModel` class.
- Implemented a `build()` static constructor using the DTO.
- Provided a `toArray()` method for array-based responses.
- Added a PHPUnit test to assert all attributes and verify correctness via `toArray()` output.