### PR TITLE
Implement controller method to retrieve all posts for a user with pagination

### DIFF
--- a/.idea/workspace.xml
+++ b/.idea/workspace.xml
@@ -5,9 +5,9 @@
   </component>
   <component name="ChangeListManager">
     <list default="true" id="6952a861-17ec-40ad-b866-c564752c14a8" name="変更" comment="">
-      <change afterPath="$PROJECT_DIR$/src/app/Post/Presentation/PresentationTest/GetAllUserPostViewModelTest.php" afterDir="false" />
-      <change afterPath="$PROJECT_DIR$/src/app/Post/Presentation/ViewModel/GetAllUserPostViewModel.php" afterDir="false" />
+      <change afterPath="$PROJECT_DIR$/src/app/Post/Presentation/PresentationTest/Controller/PostController_getAllUserPostTest.php" afterDir="false" />
       <change beforePath="$PROJECT_DIR$/.idea/workspace.xml" beforeDir="false" afterPath="$PROJECT_DIR$/.idea/workspace.xml" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/app/Post/Presentation/Controller/PostController.php" beforeDir="false" afterPath="$PROJECT_DIR$/src/app/Post/Presentation/Controller/PostController.php" afterDir="false" />
     </list>
     <option name="SHOW_DIALOG" value="false" />
     <option name="HIGHLIGHT_CONFLICTS" value="true" />
@@ -163,7 +163,7 @@
     "PHPUnit.メイン.executor": "Run",
     "RunOnceActivity.ShowReadmeOnStart": "true",
     "RunOnceActivity.git.unshallow": "true",
-    "git-widget-placeholder": "feature/show-post-index-presentation-viewmodel",
+    "git-widget-placeholder": "feature/show-post-index-presentation-controller",
     "node.js.detected.package.eslint": "true",
     "node.js.selected.package.eslint": "(autodetect)",
     "nodejs_package_manager_path": "npm",

--- a/src/app/Post/Presentation/PresentationTest/Controller/PostController_getAllUserPostTest.php
+++ b/src/app/Post/Presentation/PresentationTest/Controller/PostController_getAllUserPostTest.php
@@ -1,0 +1,147 @@
+<?php
+
+namespace App\Post\Presentation\PresentationTest\Controller;
+
+use App\Post\Application\UseCase\GetAllUserPostUseCase;
+use Illuminate\Http\Request;
+use Tests\TestCase;
+use App\Post\Presentation\Controller\PostController;
+use Mockery;
+use App\Common\Application\Dto\Pagination as PaginationDto;
+use App\Common\Presentation\ViewModelFactory\PaginationFactory;
+use App\Post\Presentation\ViewModel\GetAllUserPostViewModel;
+use App\Common\Presentation\ViewModel\Pagination as PaginationViewModel;
+use Illuminate\Http\JsonResponse;
+
+class PostController_getAllUserPostTest extends TestCase
+{
+    private int $userId;
+    private int $perPage;
+    private int $currentPage;
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->controller = new PostController();
+        $this->userId = 1;
+        $this->perPage = 10;
+        $this->currentPage = 1;
+    }
+
+    protected function tearDown(): void
+    {
+        parent::tearDown();
+    }
+
+    private function mockUseCase(): GetAllUserPostUseCase
+    {
+        $mock = Mockery::mock(GetAllUserPostUseCase::class);
+
+        $mock
+            ->shouldReceive('handle')
+            ->with(
+                Mockery::type('int'),
+                Mockery::type('int'),
+                Mockery::type('int')
+            )
+            ->andReturn($this->mockPaginationDto());
+
+        return $mock;
+    }
+
+    private function mockPaginationDto(): PaginationDto
+    {
+        $mock = Mockery::mock(PaginationDto::class);
+
+        $mock
+            ->shouldReceive('getCurrentPage')
+            ->andReturn($this->currentPage);
+
+        $mock
+            ->shouldReceive('getPerPage')
+            ->andReturn($this->perPage);
+
+        return $mock;
+    }
+
+    private function mockViewModel(): GetAllUserPostViewModel
+    {
+        $mock = Mockery::mock(GetAllUserPostViewModel::class);
+
+        $mock
+            ->shouldReceive('build')
+            ->with(Mockery::type(PaginationDto::class))
+            ->andReturn($mock);
+
+        $mock
+            ->shouldReceive('toArray')
+            ->andReturn([]);
+
+        return $mock;
+    }
+
+    private function mockPaginationViewModel(): PaginationViewModel
+    {
+        $factory = Mockery::mock(
+            'alias:' . PaginationFactory::class
+        );
+
+        $viewModel = Mockery::mock(
+            PaginationViewModel::class
+        );
+
+        $factory
+            ->shouldReceive('build')
+            ->with(
+                Mockery::type(PaginationDto::class),
+                Mockery::type('array')
+            )
+            ->andReturn($viewModel);
+
+        $viewModel
+            ->shouldReceive('toArray')
+            ->andReturn([
+                'currentPage' => $this->currentPage,
+                'perPage' => $this->perPage,
+                'total' => 100,
+                'lastPage' => 10,
+                'from' => 1,
+                'to' => 10,
+                'path' => '/api/posts',
+                'firstPageUrl' => '/api/posts?page=1',
+                'lastPageUrl' => '/api/posts?page=10',
+                'nextPageUrl' => '/api/posts?page=2',
+                'prevPageUrl' => null,
+                'links' => [],
+            ]);
+
+        return $viewModel;
+    }
+
+    private function mockRequest(): Request
+    {
+        $mock = Mockery::mock(Request::class);
+
+        $mock
+            ->shouldReceive('query')
+            ->with('current_page', 1)
+            ->andReturn($this->currentPage);
+
+        $mock
+            ->shouldReceive('query')
+            ->with('per_page', 10)
+            ->andReturn($this->perPage);
+
+        return $mock;
+    }
+
+    public function test_check_response_type(): void
+    {
+        $response = $this->controller->getAllPosts(
+            $this->userId,
+            $this->mockRequest(),
+            $this->mockUseCase(),
+        );
+
+        $this->assertInstanceOf(JsonResponse::class, $response);
+    }
+}


### PR DESCRIPTION
## Description

This pull request introduces a controller-level implementation to retrieve all posts for a given user, with pagination support. It leverages the `GetAllUserPostUseCase` to abstract domain logic, and returns JSON-formatted results including pagination metadata.

### Key Points:
- Accepts pagination inputs (`per_page`, `current_page`) from the `Request` object.
- Uses `GetAllUserPostUseCase` to obtain a `Pagination` DTO.
- Transforms data via ViewModels into an appropriate JSON response structure.
- Centralised transformation logic is delegated to `PaginationFactory`.
- Includes basic exception handling with HTTP 500 fallback.
