### PR TITLE
Merge ViewModel and Controller for Post Retrieval in Presentation Layer

### DIFF
--- a/.idea/workspace.xml
+++ b/.idea/workspace.xml
@@ -5,8 +5,8 @@
   </component>
   <component name="ChangeListManager">
     <list default="true" id="6952a861-17ec-40ad-b866-c564752c14a8" name="変更" comment="">
-      <change afterPath="$PROJECT_DIR$/src/app/Post/Application/ApplicationTest/GetAllUserPostUseCaseTest.php" afterDir="false" />
-      <change afterPath="$PROJECT_DIR$/src/app/Post/Application/UseCase/GetAllUserPostUseCase.php" afterDir="false" />
+      <change afterPath="$PROJECT_DIR$/src/app/Post/Presentation/PresentationTest/GetAllUserPostViewModelTest.php" afterDir="false" />
+      <change afterPath="$PROJECT_DIR$/src/app/Post/Presentation/ViewModel/GetAllUserPostViewModel.php" afterDir="false" />
       <change beforePath="$PROJECT_DIR$/.idea/workspace.xml" beforeDir="false" afterPath="$PROJECT_DIR$/.idea/workspace.xml" afterDir="false" />
     </list>
     <option name="SHOW_DIALOG" value="false" />
@@ -163,7 +163,7 @@
     "PHPUnit.メイン.executor": "Run",
     "RunOnceActivity.ShowReadmeOnStart": "true",
     "RunOnceActivity.git.unshallow": "true",
-    "git-widget-placeholder": "feature/show-post-index-application-usecase",
+    "git-widget-placeholder": "feature/show-post-index-presentation-viewmodel",
     "node.js.detected.package.eslint": "true",
     "node.js.selected.package.eslint": "(autodetect)",
     "nodejs_package_manager_path": "npm",

--- a/.idea/workspace.xml
+++ b/.idea/workspace.xml
@@ -4,11 +4,7 @@
     <option name="autoReloadType" value="SELECTIVE" />
   </component>
   <component name="ChangeListManager">
-    <list default="true" id="6952a861-17ec-40ad-b866-c564752c14a8" name="変更" comment="">
-      <change afterPath="$PROJECT_DIR$/src/app/Post/Presentation/PresentationTest/GetAllUserPostViewModelTest.php" afterDir="false" />
-      <change afterPath="$PROJECT_DIR$/src/app/Post/Presentation/ViewModel/GetAllUserPostViewModel.php" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/.idea/workspace.xml" beforeDir="false" afterPath="$PROJECT_DIR$/.idea/workspace.xml" afterDir="false" />
-    </list>
+    <list default="true" id="6952a861-17ec-40ad-b866-c564752c14a8" name="変更" comment="" />
     <option name="SHOW_DIALOG" value="false" />
     <option name="HIGHLIGHT_CONFLICTS" value="true" />
     <option name="HIGHLIGHT_NON_ACTIVE_CHANGELIST" value="false" />
@@ -163,7 +159,7 @@
     "PHPUnit.メイン.executor": "Run",
     "RunOnceActivity.ShowReadmeOnStart": "true",
     "RunOnceActivity.git.unshallow": "true",
-    "git-widget-placeholder": "feature/show-post-index-presentation-viewmodel",
+    "git-widget-placeholder": "feature/show-post-index-presentation-controller",
     "node.js.detected.package.eslint": "true",
     "node.js.selected.package.eslint": "(autodetect)",
     "nodejs_package_manager_path": "npm",

--- a/src/app/Post/Presentation/PresentationTest/Controller/PostController_getAllUserPostTest.php
+++ b/src/app/Post/Presentation/PresentationTest/Controller/PostController_getAllUserPostTest.php
@@ -1,0 +1,115 @@
+<?php
+
+namespace App\Post\Presentation\PresentationTest\Controller;
+
+use App\Post\Application\UseCase\GetAllUserPostUseCase;
+use Illuminate\Http\Request;
+use Tests\TestCase;
+use App\Post\Presentation\Controller\PostController;
+use Mockery;
+use App\Common\Application\Dto\Pagination as PaginationDto;
+use App\Common\Presentation\ViewModelFactory\PaginationFactory;
+use App\Post\Presentation\ViewModel\GetAllUserPostViewModel;
+use App\Common\Presentation\ViewModel\Pagination as PaginationViewModel;
+use Illuminate\Http\JsonResponse;
+
+class PostController_getAllUserPostTest extends TestCase
+{
+    private int $userId;
+    private int $perPage;
+    private int $currentPage;
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->controller = new PostController();
+        $this->userId = 1;
+        $this->perPage = 10;
+        $this->currentPage = 1;
+    }
+
+    protected function tearDown(): void
+    {
+        parent::tearDown();
+    }
+
+    private function mockUseCase(): GetAllUserPostUseCase
+    {
+        $mock = Mockery::mock(GetAllUserPostUseCase::class);
+
+        $mock
+            ->shouldReceive('handle')
+            ->with(
+                Mockery::type('int'),
+                Mockery::type('int'),
+                Mockery::type('int')
+            )
+            ->andReturn($this->mockPaginationDto());
+
+        return $mock;
+    }
+
+    private function mockPaginationDto(): PaginationDto
+    {
+        $mock = Mockery::mock(PaginationDto::class);
+
+        $mock
+            ->shouldReceive('getCurrentPage')
+            ->andReturn($this->currentPage);
+
+        $mock
+            ->shouldReceive('getPerPage')
+            ->andReturn($this->perPage);
+
+        $mock
+            ->shouldReceive('getData')
+            ->andReturn([
+                $this->mockViewModel(),
+            ]);
+
+        return $mock;
+    }
+
+    private function mockViewModel(): GetAllUserPostViewModel
+    {
+        $mock = Mockery::mock(GetAllUserPostViewModel::class);
+
+        $mock
+            ->shouldReceive('build')
+            ->with(Mockery::type(PaginationDto::class))
+            ->andReturn($mock);
+
+        $mock
+            ->shouldReceive('toArray')
+            ->andReturn([]);
+
+        return $mock;
+    }
+
+    private function mockRequest(): Request
+    {
+        $mock = Mockery::mock(Request::class);
+
+        $mock
+            ->shouldReceive('query')
+            ->with('current_page', 1)
+            ->andReturn($this->currentPage);
+
+        $mock
+            ->shouldReceive('query')
+            ->with('per_page', 10)
+            ->andReturn($this->perPage);
+
+        return $mock;
+    }
+
+    public function test_check_response_type(): void
+    {
+        $response = $this->controller->getAllPosts(
+            $this->userId,
+            $this->mockRequest(),
+            $this->mockUseCase(),
+        );
+
+        $this->assertInstanceOf(JsonResponse::class, $response);
+    }
+}

--- a/src/app/Post/Presentation/PresentationTest/GetAllUserPostViewModelTest.php
+++ b/src/app/Post/Presentation/PresentationTest/GetAllUserPostViewModelTest.php
@@ -1,0 +1,76 @@
+<?php
+
+namespace App\Post\Presentation\PresentationTest;
+
+use App\Post\Presentation\ViewModel\GetAllUserPostViewModel;
+use Tests\TestCase;
+use App\Post\Application\Dto\GetAllUserPostDto;
+use Mockery;
+
+class GetAllUserPostViewModelTest extends TestCase
+{
+    private int $userId;
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->userId = 1;
+    }
+
+    protected function tearDown(): void
+    {
+        parent::tearDown();
+    }
+
+    private function arrayMultiData(): array
+    {
+        return [
+            [
+                'id' => 1,
+                'userId' => $this->userId,
+                'content' => 'Sample post content',
+                'mediaPath' => 'path/to/media.jpg',
+                'visibility' => 'public',
+            ],
+            [
+                'id' => 2,
+                'userId' => $this->userId,
+                'content' => 'Another post content',
+                'mediaPath' => 'path/to/another_media.jpg',
+                'visibility' => 'private',
+            ],
+        ];
+    }
+
+    private function mockDto(): GetAllUserPostDto
+    {
+        $mock = Mockery::mock(GetAllUserPostDto::class);
+
+        $mock
+            ->shouldReceive('toArray')
+            ->andReturn($this->arrayMultiData()[0]);
+
+        return $mock;
+    }
+
+    public function test_view_model_check_type(): void
+    {
+        $result = GetAllUserPostViewModel::build(
+            $this->mockDto()
+        );
+
+        $this->assertInstanceOf(GetAllUserPostViewModel::class, $result);
+    }
+
+    public function test_view_model_check_value(): void
+    {
+        $result = GetAllUserPostViewModel::build(
+            $this->mockDto()
+        );
+
+        $this->assertSame($this->arrayMultiData()[0]['id'], $result->toArray()['id']);
+        $this->assertSame($this->arrayMultiData()[0]['userId'], $result->toArray()['userId']);
+        $this->assertSame($this->arrayMultiData()[0]['content'], $result->toArray()['content']);
+        $this->assertSame($this->arrayMultiData()[0]['mediaPath'], $result->toArray()['mediaPath']);
+        $this->assertSame($this->arrayMultiData()[0]['visibility'], $result->toArray()['visibility']);
+    }
+}

--- a/src/app/Post/Presentation/ViewModel/GetAllUserPostViewModel.php
+++ b/src/app/Post/Presentation/ViewModel/GetAllUserPostViewModel.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace App\Post\Presentation\ViewModel;
+
+use App\Post\Application\Dto\GetAllUserPostDto;
+
+class GetAllUserPostViewModel
+{
+    public function __construct(
+        private int $id,
+        private int $userId,
+        private string $content,
+        private ?string $mediaPath,
+        private string $visibility
+    ) {}
+
+    public static function build(GetAllUserPostDto $data): self
+    {
+        $dtoArray = $data->toArray();
+        return new self(
+            id: $dtoArray['id'],
+            userId: $dtoArray['userId'],
+            content: $dtoArray['content'],
+            mediaPath: $dtoArray['mediaPath'] ?? null,
+            visibility: $dtoArray['visibility']
+        );
+    }
+
+    public function toArray(): array
+    {
+        return [
+            'id' => $this->id,
+            'userId' => $this->userId,
+            'content' => $this->content,
+            'mediaPath' => $this->mediaPath,
+            'visibility' => $this->visibility
+        ];
+    }
+}


### PR DESCRIPTION
### Description

This pull request integrates the ViewModel and Controller logic for the Post module into the Presentation layer.

#### Changes introduced:
- Implemented `GetAllUserPostViewModel` to structure individual post responses.
- Developed `getAllPosts` method in the controller to handle incoming requests and apply pagination logic.
- Mapped DTO data to view models and returned structured JSON responses.
- Included exception handling with consistent response formatting.
