### PR TITLE
 Implement `getEachUserPost` method 

### DIFF
--- a/.idea/workspace.xml
+++ b/.idea/workspace.xml
@@ -5,7 +5,14 @@
   </component>
   <component name="ChangeListManager">
     <list default="true" id="6952a861-17ec-40ad-b866-c564752c14a8" name="変更" comment="">
+      <change afterPath="$PROJECT_DIR$/src/app/Post/Infrastructure/InfrastructureTest/GetEachPostQueryServiceTest.php" afterDir="false" />
       <change beforePath="$PROJECT_DIR$/.idea/workspace.xml" beforeDir="false" afterPath="$PROJECT_DIR$/.idea/workspace.xml" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/app/Post/Application/ApplicationTest/GetAllUserPostUseCaseTest.php" beforeDir="false" afterPath="$PROJECT_DIR$/src/app/Post/Application/ApplicationTest/GetAllUserPostUseCaseTest.php" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/app/Post/Application/QueryServiceInterface/GetAllUserPostQueryServiceInterface.php" beforeDir="false" afterPath="$PROJECT_DIR$/src/app/Post/Application/QueryServiceInterface/GetPostQueryServiceInterface.php" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/app/Post/Application/UseCase/GetAllUserPostUseCase.php" beforeDir="false" afterPath="$PROJECT_DIR$/src/app/Post/Application/UseCase/GetAllUserPostUseCase.php" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/app/Post/Infrastructure/InfrastructureTest/GetAllUserPostQueryServiceTest.php" beforeDir="false" afterPath="$PROJECT_DIR$/src/app/Post/Infrastructure/InfrastructureTest/GetAllUserPostQueryServiceTest.php" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/app/Post/Infrastructure/QueryService/GetAllUserPostQueryService.php" beforeDir="false" afterPath="$PROJECT_DIR$/src/app/Post/Infrastructure/QueryService/GetPostQueryService.php" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/app/Providers/AppServiceProvider.php" beforeDir="false" afterPath="$PROJECT_DIR$/src/app/Providers/AppServiceProvider.php" afterDir="false" />
     </list>
     <option name="SHOW_DIALOG" value="false" />
     <option name="HIGHLIGHT_CONFLICTS" value="true" />
@@ -161,7 +168,7 @@
     "PHPUnit.メイン.executor": "Run",
     "RunOnceActivity.ShowReadmeOnStart": "true",
     "RunOnceActivity.git.unshallow": "true",
-    "git-widget-placeholder": "feature/show-each-post-domain-query-service-interface",
+    "git-widget-placeholder": "feature/show-each-post-infra-queryservice",
     "node.js.detected.package.eslint": "true",
     "node.js.selected.package.eslint": "(autodetect)",
     "nodejs_package_manager_path": "npm",

--- a/src/app/Post/Application/ApplicationTest/GetAllUserPostUseCaseTest.php
+++ b/src/app/Post/Application/ApplicationTest/GetAllUserPostUseCaseTest.php
@@ -3,7 +3,7 @@
 namespace App\Post\Application\ApplicationTest;
 
 use App\Common\Domain\ValueObject\UserId;
-use App\Post\Application\QueryServiceInterface\GetAllUserPostQueryServiceInterface;
+use App\Post\Application\QueryServiceInterface\GetPostQueryServiceInterface;
 use Tests\TestCase;
 use Mockery;
 use App\Post\Application\Dto\GetAllUserPostDto;
@@ -45,9 +45,9 @@ class GetAllUserPostUseCaseTest extends TestCase
         ];
     }
 
-    private function mockQueryService(): GetAllUserPostQueryServiceInterface
+    private function mockQueryService(): GetPostQueryServiceInterface
     {
-        $mock = Mockery::mock(GetAllUserPostQueryServiceInterface::class);
+        $mock = Mockery::mock(GetPostQueryServiceInterface::class);
 
         $mock->shouldReceive('getAllUserPosts')
             ->with(

--- a/src/app/Post/Application/QueryServiceInterface/GetPostQueryServiceInterface.php
+++ b/src/app/Post/Application/QueryServiceInterface/GetPostQueryServiceInterface.php
@@ -4,8 +4,10 @@ namespace App\Post\Application\QueryServiceInterface;
 
 use App\Post\Domain\Entity\PostEntity;
 use App\Common\Application\Dto\Pagination as PaginationDto;
+use App\Common\Domain\ValueObject\PostId;
+use App\Common\Domain\ValueObject\UserId;
 
-interface GetAllUserPostQueryServiceInterface
+interface GetPostQueryServiceInterface
 {
     public function getAllUserPosts(
         int $userId,
@@ -14,7 +16,7 @@ interface GetAllUserPostQueryServiceInterface
     ): PaginationDto;
 
     public function getEachUserPost(
-        int $userId,
-        int $postId
+        UserId $userId,
+        PostId $postId
     ): ?PostEntity;
 }

--- a/src/app/Post/Application/UseCase/GetAllUserPostUseCase.php
+++ b/src/app/Post/Application/UseCase/GetAllUserPostUseCase.php
@@ -4,14 +4,14 @@ namespace App\Post\Application\UseCase;
 
 
 use App\Common\Application\Dto\Pagination;
-use App\Post\Application\QueryServiceInterface\GetAllUserPostQueryServiceInterface;
+use App\Post\Application\QueryServiceInterface\GetPostQueryServiceInterface;
 use App\Post\Application\Dto\GetAllUserPostDto;
 use App\Post\Domain\Entity\PostEntity;
 
 class GetAllUserPostUseCase
 {
     public function __construct(
-        private readonly GetAllUserPostQueryServiceInterface $queryService
+        private readonly GetPostQueryServiceInterface $queryService
     ) {}
 
     public function handle(

--- a/src/app/Post/Infrastructure/InfrastructureTest/GetAllUserPostQueryServiceTest.php
+++ b/src/app/Post/Infrastructure/InfrastructureTest/GetAllUserPostQueryServiceTest.php
@@ -4,10 +4,10 @@ namespace App\Post\Infrastructure\InfrastructureTest;
 
 use App\Common\Application\Dto\Pagination;
 use App\Post\Domain\Entity\PostEntity;
-use App\Post\Infrastructure\QueryService\GetAllUserPostQueryService;
+use App\Post\Infrastructure\QueryService\GetPostQueryService;
 use Illuminate\Support\Facades\DB;
 use Tests\TestCase;
-use App\Post\Application\QueryServiceInterface\GetAllUserPostQueryServiceInterface;
+use App\Post\Application\QueryServiceInterface\GetPostQueryServiceInterface;
 use App\Post\Domain\Entity\PostEntityCollection;
 use Mockery;
 use App\Post\Domain\EntityFactory\PostFromModelEntityFactory;
@@ -33,7 +33,8 @@ class GetAllUserPostQueryServiceTest extends TestCase
     {
         parent::setUp();
         $this->refresh();
-        $this->user = User::create([
+        $this->user = new User();
+        User::create([
             'first_name' => 'Sergio',
             'last_name' => 'Ramos',
             'email' => 'real-madrid15@test.com',
@@ -43,10 +44,14 @@ class GetAllUserPostQueryServiceTest extends TestCase
             'skills' => ['Football', 'Leadership'],
             'profile_image' => 'https://example.com/sergio.jpg'
         ]);
+
         $this->post = new Post();
         $this->createDummyPosts();
 
-        $this->queryService = new GetAllUserPostQueryService($this->post);
+        $this->queryService = new GetPostQueryService(
+            $this->post,
+            $this->user
+        );
     }
 
     protected function tearDown(): void

--- a/src/app/Post/Infrastructure/InfrastructureTest/GetEachPostQueryServiceTest.php
+++ b/src/app/Post/Infrastructure/InfrastructureTest/GetEachPostQueryServiceTest.php
@@ -1,0 +1,148 @@
+<?php
+
+namespace App\Post\Infrastructure\InfrastructureTest;
+
+use App\Post\Domain\Entity\PostEntity;
+use App\Post\Domain\ValueObject\Postvisibility;
+use App\Post\Infrastructure\QueryService\GetPostQueryService;
+use Illuminate\Support\Facades\DB;
+use Tests\TestCase;
+use App\Common\Domain\ValueObject\UserId;
+use App\Common\Domain\ValueObject\PostId;
+use App\Post\Application\QueryServiceInterface\GetPostQueryServiceInterface;
+use App\Models\Post;
+use App\Models\User;
+use Mockery;
+use App\Common\Domain\Enum\PostVisibility as PostVisibilityEnum;
+
+class GetEachPostQueryServiceTest extends TestCase
+{
+    private GetPostQueryServiceInterface $queryService;
+    private $user;
+    private $post;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->refresh();
+        $this->user = User::create(([
+            'first_name' => 'Sergio',
+            'last_name' => 'Ramos',
+            'email' => 'real-madrid15@test.com',
+            'password' => 'el-capitán-1234',
+            'bio' => 'Real Madrid player',
+            'location' => 'Madrid',
+            'skills' => ['Football', 'Leadership'],
+            'profile_image' => 'https://example.com/sergio.jpg'
+        ]));
+
+        $this->post = $this->createPostData();
+        $this->queryService = new GetPostQueryService(
+            $this->post,
+            $this->user
+        );
+    }
+
+    protected function tearDown(): void
+    {
+        $this->refresh();
+        parent::tearDown();
+    }
+
+    private function createPostData(): Post
+    {
+        $post = Post::create([
+            'user_id' => $this->user->id,
+            'content' => 'Cristiano Ronaldo is a legendary footballer known for his incredible skills and goal-scoring ability.',
+            'media_path' => 'https://example.com/media.jpg',
+            'visibility' => 'public',
+        ]);
+
+        return $post;
+    }
+
+    private function refresh(): void
+    {
+        if (env('APP_ENV') === 'testing') {
+            DB::connection('mysql')->statement('SET FOREIGN_KEY_CHECKS=0;');
+            User::truncate();
+            Post::truncate();
+            DB::connection('mysql')->statement('SET FOREIGN_KEY_CHECKS=1;');
+        }
+    }
+
+    private function mockEntity(): PostEntity
+    {
+        $mock = Mockery::mock(PostEntity::class);
+
+        $mock
+            ->shouldReceive('getId')
+            ->andReturn(new PostId($this->post->id));
+
+        $mock
+            ->shouldReceive('getUserId')
+            ->andReturn(new UserId($this->user->id));
+
+        $mock
+            ->shouldReceive('getContent')
+            ->andReturn($this->createPostData()['content']);
+
+        $mock
+            ->shouldReceive('getMediaPath')
+            ->andReturn($this->createPostData()['media_path']);
+
+        $mock
+            ->shouldReceive('getPostVisibility')
+            ->andReturn(new Postvisibility(
+                PostVisibilityEnum::from($this->createPostData()['visibility'])
+            ));
+
+        return $mock;
+    }
+
+    public function test_check_method_return_type(): void
+    {
+        $result = $this->queryService->getEachUserPost(
+            new UserId($this->user->id),
+            new PostId($this->post->id)
+        );
+
+        $this->assertInstanceOf(
+            PostEntity::class,
+            $result
+        );
+    }
+
+    public function test_check_method_return_value(): void
+    {
+        $result = $this->queryService->getEachUserPost(
+            new UserId($this->user->id),
+            new PostId($this->post->id)
+        );
+
+        $this->assertEquals(
+            $this->mockEntity()->getId(),
+            $result->getId()
+        );
+
+        $this->assertEquals(
+            $this->mockEntity()->getUserId(),
+            $result->getUserId()
+        );
+
+        $this->assertEquals(
+            $this->mockEntity()->getContent(),
+            $result->getContent()
+        );
+
+        $this->assertEquals(
+            $this->mockEntity()->getMediaPath(),
+            $result->getMediaPath()
+        );
+
+        $this->assertEquals(
+            $this->mockEntity()->getPostVisibility(),
+            $result->getPostVisibility()
+        );
+    }
+}

--- a/src/app/Post/Infrastructure/QueryService/GetPostQueryService.php
+++ b/src/app/Post/Infrastructure/QueryService/GetPostQueryService.php
@@ -2,14 +2,17 @@
 
 namespace App\Post\Infrastructure\QueryService;
 
+use App\Common\Domain\ValueObject\PostId;
+use App\Common\Domain\ValueObject\UserId;
 use App\Models\Post;
-use App\Post\Application\QueryServiceInterface\GetAllUserPostQueryServiceInterface;
+use App\Post\Application\QueryServiceInterface\GetPostQueryServiceInterface;
+use App\Post\Domain\Entity\PostEntity;
 use App\Post\Domain\EntityFactory\PostFromModelEntityFactory;
 use App\Common\Application\Dto\Pagination as PaginationDto;
 use App\Models\User;
 use ErrorException;
 
-class GetAllUserPostQueryService implements GetAllUserPostQueryServiceInterface
+class GetPostQueryService implements GetPostQueryServiceInterface
 {
     public function __construct(
         private readonly Post $post,
@@ -37,6 +40,23 @@ class GetAllUserPostQueryService implements GetAllUserPostQueryServiceInterface
             );
 
         return $this->paginationDto($userPosts->toArray());
+    }
+
+    public function getEachUserPost(
+        UserId $userId,
+        PostId $postId
+    ): ?PostEntity
+    {
+        $post = $this->post
+            ->where('user_id', $userId->getValue())
+            ->where('id', $postId->getValue())
+            ->first();
+
+        if (!$post) {
+            return null;
+        }
+
+        return PostFromModelEntityFactory::build($post->toArray());
     }
 
     private function paginationDto(

--- a/src/app/Providers/AppServiceProvider.php
+++ b/src/app/Providers/AppServiceProvider.php
@@ -2,7 +2,7 @@
 
 namespace App\Providers;
 
-use App\Post\Application\QueryServiceInterface\GetAllUserPostQueryServiceInterface;
+use App\Post\Application\QueryServiceInterface\GetPostQueryServiceInterface;
 use App\Post\Domain\RepositoryInterface\PostRepositoryInterface;
 use App\Post\Infrastructure\Repository\PostRepository;
 use App\User\Domain\RepositoryInterface\PasswordHasherInterface;
@@ -14,7 +14,7 @@ use App\User\Infrastructure\Service\BcryptPasswordHasher;
 use App\User\Domain\Service\GenerateTokenInterface;
 use App\User\Infrastructure\Service\GenerateTokenService;
 use App\User\Domain\Service\AuthServiceInterface;
-use App\Post\Infrastructure\QueryService\GetAllUserPostQueryService;
+use App\Post\Infrastructure\QueryService\GetPostQueryService;
 
 class AppServiceProvider extends ServiceProvider
 {
@@ -54,8 +54,8 @@ class AppServiceProvider extends ServiceProvider
         );
 
         $this->app->bind(
-            GetAllUserPostQueryServiceInterface::class,
-            GetAllUserPostQueryService::class
+            GetPostQueryServiceInterface::class,
+            GetPostQueryService::class
         );
     }
 


### PR DESCRIPTION
## Description

This pull request introduces the `getEachUserPost(UserId $userId, PostId $postId): ?PostEntity` method to `GetEachPostQueryService`, enabling retrieval of a specific post by user ID and post ID pair. It ensures that only posts belonging to the given user are returned.