### PR TITLE
 Add controller method `getEachPost` and its corresponding feature test

### DIFF
--- a/.idea/workspace.xml
+++ b/.idea/workspace.xml
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="AutoImportSettings">
+    <option name="autoReloadType" value="SELECTIVE" />
+  </component>
+  <component name="ChangeListManager">
+    <list default="true" id="27da8af9-c148-42c6-9dab-320e0da42b45" name="変更" comment="fix: test-environment-fix">
+      <change afterPath="$PROJECT_DIR$/src/app/Post/Presentation/PresentationTest/Controller/PostController_getEachUserPostTest.php" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/.idea/workspace.xml" beforeDir="false" afterPath="$PROJECT_DIR$/.idea/workspace.xml" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/app/Post/Presentation/Controller/PostController.php" beforeDir="false" afterPath="$PROJECT_DIR$/src/app/Post/Presentation/Controller/PostController.php" afterDir="false" />
+    </list>
+    <option name="SHOW_DIALOG" value="false" />
+    <option name="HIGHLIGHT_CONFLICTS" value="true" />
+    <option name="HIGHLIGHT_NON_ACTIVE_CHANGELIST" value="false" />
+    <option name="LAST_RESOLUTION" value="IGNORE" />
+  </component>
+  <component name="ComposerSettings">
+    <execution />
+  </component>
+  <component name="Git.Settings">
+    <option name="RECENT_GIT_ROOT_PATH" value="$PROJECT_DIR$" />
+  </component>
+  <component name="PropertiesComponent"><![CDATA[{
+  "keyToString": {
+    "git-widget-placeholder": "feature/show-each-post-presentation-controller"
+  }
+}]]></component>
+  <component name="RunManager">
+    <configuration default="true" type="ComposerRunConfigurationType" factoryName="Composer Script">
+      <method v="2" />
+    </configuration>
+  </component>
+  <component name="VcsManagerConfiguration">
+    <MESSAGE value="fix: test-environment-fix" />
+    <option name="LAST_COMMIT_MESSAGE" value="fix: test-environment-fix" />
+  </component>
+  <component name="XSLT-Support.FileAssociations.UIState">
+    <expand />
+    <select />
+  </component>
+</project>

--- a/src/app/Post/Presentation/Controller/PostController.php
+++ b/src/app/Post/Presentation/Controller/PostController.php
@@ -4,6 +4,7 @@ namespace App\Post\Presentation\Controller;
 
 use App\Http\Controllers\Controller;
 use App\Post\Application\UseCase\CreateUseCase;
+use App\Post\Application\UseCase\GetUserEachPostUseCase;
 use App\Post\Presentation\ViewModel\CreatePostViewModel;
 use App\Post\Application\UseCommand\CreatePostUseCommand;
 use Illuminate\Http\JsonResponse;
@@ -81,6 +82,33 @@ class PostController extends Controller
                 'data' => $paginationViewModel['data'],
                 'meta' => $paginationViewModel['meta'],
             ]);
+
+        } catch (Throwable $e) {
+            return response()->json([
+                'status' => 'error',
+                'message' => $e->getMessage(),
+            ], 500);
+        }
+    }
+
+    public function getEachPost(
+        int $userId,
+        int $postId,
+        GetUserEachPostUseCase $useCase
+    ): JsonResponse
+    {
+        try {
+            $dto = $useCase->handle(
+                userId: $userId,
+                postId: $postId
+            );
+
+            $viewModelArray = GetAllUserPostViewModel::build($dto)->toArray();
+
+            return response()->json([
+                'status' => 'success',
+                'data' => $viewModelArray,
+            ], 200);
 
         } catch (Throwable $e) {
             return response()->json([

--- a/src/app/Post/Presentation/PresentationTest/Controller/PostController_getEachUserPostTest.php
+++ b/src/app/Post/Presentation/PresentationTest/Controller/PostController_getEachUserPostTest.php
@@ -1,0 +1,87 @@
+<?php
+
+namespace App\Post\Presentation\PresentationTest\Controller;
+
+use Illuminate\Http\JsonResponse;
+use Tests\TestCase;
+use App\Post\Presentation\ViewModel\GetAllUserPostViewModel;
+use App\Post\Application\Dto\GetUserEachPostDto;
+use Mockery;
+use App\Post\Application\UseCase\GetUserEachPostUseCase;
+use App\Post\Presentation\Controller\PostController;
+
+class PostController_getEachUserPostTest extends TestCase
+{
+    private $userId;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->controller = new PostController();
+        $this->userId = 1;
+    }
+
+    protected function tearDown(): void
+    {
+        parent::tearDown();
+    }
+
+    private function mockUseCase(): GetUserEachPostUseCase
+    {
+        $useCase = Mockery::mock(GetUserEachPostUseCase::class);
+
+        $useCase
+            ->shouldReceive('handle')
+            ->with(
+                Mockery::type('int'),
+                Mockery::type('int'),
+            )
+            ->andReturn($this->mockViewModel());
+
+        return $useCase;
+    }
+
+    private function mockViewModel(): GetAllUserPostViewModel
+    {
+        $viewModel = Mockery::mock(GetAllUserPostViewModel::class);
+
+        $viewModel
+            ->shouldReceive('toArray')
+            ->andReturn([]);
+
+        return $viewModel;
+    }
+
+    private function mockDto(): GetUserEachPostDto
+    {
+        $dto = Mockery::mock(GetUserEachPostDto::class);
+
+        $dto
+            ->shouldReceive('toArray')
+            ->andReturn($this->arrayData());
+
+        return $dto;
+    }
+
+    private function arrayData(): array
+    {
+        return [
+            'id' => 1,
+            'userId' => $this->userId,
+            'content' => 'Sample post content',
+            'mediaPath' => 'https://example.com/media.jpg',
+            'visibility' => 'public',
+        ];
+    }
+
+    public function test_controller_method(): void
+    {
+        $response = $this->controller->getEachPost(
+            $this->userId,
+            $this->arrayData()['id'],
+            $this->mockUseCase()
+        );
+
+        $this->assertInstanceOf(JsonResponse::class, $response);
+    }
+}


### PR DESCRIPTION
## Description

This PR adds the `getEachPost` method to the controller, allowing retrieval of a single post for a specific user via `GetUserEachPostUseCase`.

The controller method handles the following:
- Accepts `userId` and `postId` via route parameters.
- Delegates the logic to `GetUserEachPostUseCase`.
- Transforms the resulting DTO to array format via `GetAllUserPostViewModel`.
- Returns a JSON response with success or error status.
