### PR TITLE
Implement EditPostEntityFactory for Immutable Entity Updates

### DIFF
--- a/src/app/Post/Domain/DomainTest/EditPostEntityFactoryTest.php
+++ b/src/app/Post/Domain/DomainTest/EditPostEntityFactoryTest.php
@@ -1,0 +1,91 @@
+<?php
+
+namespace App\Post\Domain\DomainTest;
+
+use App\Common\Domain\ValueObject\UserId;
+use App\Common\Domain\ValueObject\PostId;
+use App\Post\Domain\Entity\PostEntity;
+use App\Common\Domain\Enum\PostVisibility as PostVisibilityEnum;
+use App\Post\Domain\EntityFactory\EditPostEntityFactory;
+use App\Post\Domain\ValueObject\Postvisibility;
+use Tests\TestCase;
+use InvalidArgumentException;
+
+class EditPostEntityFactoryTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+    }
+
+    protected function tearDown(): void
+    {
+        parent::tearDown();
+    }
+
+    private function arrayData(): array
+    {
+        return [
+            'id' => 1,
+            'userId' => 1,
+            'content' => 'Bruno to Ronaldo siuuuuu',
+            'mediaPath' => 'https://example.com/media.jpg',
+            'visibility' => 'public',
+        ];
+    }
+
+    private function wrongIdArrayData(): array
+    {
+        return [
+            'id' => "1",
+            'userId' => 1,
+            'content' => '',
+            'mediaPath' => 'https://example.com/media.jpg',
+            'visibility' => 'public',
+        ];
+    }
+
+    private function wrongUserIdArrayData(): array
+    {
+        return [
+            'id' => 1,
+            'userId' => "1",
+            'content' => '',
+            'mediaPath' => 'https://example.com/media.jpg',
+            'visibility' => 'public',
+        ];
+    }
+
+    public function test_check_entity_type(): void
+    {
+        $postEntity = EditPostEntityFactory::build($this->arrayData());
+
+        $this->assertInstanceOf(PostEntity::class, $postEntity);
+    }
+
+    public function test_check_entity_value(): void
+    {
+        $postEntity = EditPostEntityFactory::build($this->arrayData());
+
+        $this->assertEquals(new PostId($this->arrayData()['id']), $postEntity->getId());
+        $this->assertEquals(new UserId($this->arrayData()['userId']), $postEntity->getUserId());
+        $this->assertEquals($this->arrayData()['content'], $postEntity->getContent());
+        $this->assertEquals($this->arrayData()['mediaPath'], $postEntity->getMediaPath());
+        $this->assertEquals(
+            new Postvisibility(PostVisibilityEnum::fromString($this->arrayData()['visibility'])),
+            $postEntity->getPostVisibility()
+        );
+    }
+
+    public function test_check_wrong_user_id_type(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        EditPostEntityFactory::build($this->wrongUserIdArrayData());
+    }
+
+    public function test_check_wrong_id_type(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        EditPostEntityFactory::build($this->wrongIdArrayData());
+    }
+}

--- a/src/app/Post/Domain/EntityFactory/EditPostEntityFactory.php
+++ b/src/app/Post/Domain/EntityFactory/EditPostEntityFactory.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace App\Post\Domain\EntityFactory;
+
+use App\Common\Domain\ValueObject\UserId;
+use App\Common\Domain\ValueObject\PostId;
+use App\Post\Domain\ValueObject\PostVisibility;
+use App\Post\Domain\Entity\PostEntity;
+use App\Common\Domain\Enum\PostVisibility as PostVisibilityEnum;
+use InvalidArgumentException;
+
+class EditPostEntityFactory
+{
+    public static function build(array $request): PostEntity
+    {
+        self::validate($request);
+
+        return PostEntity::build([
+            'id' => isset($request['id']) ? new PostId($request['id']) : null,
+            'userId' => new UserId($request['userId']),
+            'content' => $request['content'],
+            'mediaPath' => $request['mediaPath'] ?? null,
+            'visibility' => new PostVisibility(PostVisibilityEnum::fromString($request['visibility']))
+        ]);
+    }
+
+    public static function validate(array $request): void
+    {
+        if (empty($request['id'])) {
+            throw new InvalidArgumentException('Post ID is required.');
+        }
+
+        if (empty($request['userId'])) {
+            throw new InvalidArgumentException('User ID is required.');
+        }
+
+        if (empty($request['content'])) {
+            throw new InvalidArgumentException('Content is required.');
+        }
+
+        if (!isset($request['visibility']) || !in_array($request['visibility'], ['public', 'private'])) {
+            throw new InvalidArgumentException('Visibility must be either "public" or "private".');
+        }
+    }
+}


### PR DESCRIPTION
### Description

This pull request introduces a dedicated factory, `EditPostEntityFactory`, to support mutation-like operations while preserving immutability for the `PostEntity`. This is particularly useful in update scenarios where entities must be rebuilt with new values without compromising the `readonly` design.