### PR TITLE
Add `editById` method to PostRepositoryInterface for post update functionality

### DIFF
--- a/src/app/Post/Domain/RepositoryInterface/PostRepositoryInterface.php
+++ b/src/app/Post/Domain/RepositoryInterface/PostRepositoryInterface.php
@@ -9,4 +9,8 @@ interface PostRepositoryInterface
     public function save(
         PostEntity $entity
     ): ?PostEntity;
+
+    public function editById(
+        PostEntity $entity
+    ): PostEntity;
 }


### PR DESCRIPTION
This PR adds the `editById(PostEntity $entity): PostEntity` method to the `PostRepositoryInterface`.

### Motivation:
As we prepare to implement post editing capabilities, this method signature will serve as the contract for all concrete implementations. It strictly accepts a validated `PostEntity` and returns the updated entity. The return type is explicitly non-nullable, aligning with the design principle that edit operations must either succeed or fail with a domain exception.

### Key Changes:
- Introduced `editById(PostEntity $entity): PostEntity` in `PostRepositoryInterface`
- No other business logic or implementation changes included in this PR