### PR TITLE
Implement `editById` method in Infrastructure layer for post updates

### DIFF
--- a/.idea/workspace.xml
+++ b/.idea/workspace.xml
@@ -5,39 +5,9 @@
   </component>
   <component name="ChangeListManager">
     <list default="true" id="6952a861-17ec-40ad-b866-c564752c14a8" name="変更" comment="fix: test-environment-fix">
+      <change afterPath="$PROJECT_DIR$/src/app/Post/Infrastructure/InfrastructureTest/EditPostRepositoryTest.php" afterDir="false" />
       <change beforePath="$PROJECT_DIR$/.idea/workspace.xml" beforeDir="false" afterPath="$PROJECT_DIR$/.idea/workspace.xml" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/src/app/User/Application/ApplicationTest/LoginUserDtoTest.php" beforeDir="false" afterPath="$PROJECT_DIR$/src/app/User/Application/ApplicationTest/LoginUserDtoTest.php" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/src/app/User/Application/ApplicationTest/LogoutUserUseCaseTest.php" beforeDir="false" afterPath="$PROJECT_DIR$/src/app/User/Application/ApplicationTest/LogoutUserUseCaseTest.php" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/src/app/User/Application/ApplicationTest/RegisterUserDtoFactoryTest.php" beforeDir="false" afterPath="$PROJECT_DIR$/src/app/User/Application/ApplicationTest/RegisterUserDtoFactoryTest.php" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/src/app/User/Application/ApplicationTest/RegisterUserUseCaseTest.php" beforeDir="false" afterPath="$PROJECT_DIR$/src/app/User/Application/ApplicationTest/RegisterUserUseCaseTest.php" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/src/app/User/Application/ApplicationTest/ShowUserDtoTest.php" beforeDir="false" afterPath="$PROJECT_DIR$/src/app/User/Application/ApplicationTest/ShowUserDtoTest.php" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/src/app/User/Application/ApplicationTest/ShowUserUseCaseTest.php" beforeDir="false" afterPath="$PROJECT_DIR$/src/app/User/Application/ApplicationTest/ShowUserUseCaseTest.php" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/src/app/User/Application/ApplicationTest/UpdateUserDtoTest.php" beforeDir="false" afterPath="$PROJECT_DIR$/src/app/User/Application/ApplicationTest/UpdateUserDtoTest.php" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/src/app/User/Application/ApplicationTest/UpdateUserUseCaseTest.php" beforeDir="false" afterPath="$PROJECT_DIR$/src/app/User/Application/ApplicationTest/UpdateUserUseCaseTest.php" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/src/app/User/Application/Dto/LoginUserDto.php" beforeDir="false" afterPath="$PROJECT_DIR$/src/app/User/Application/Dto/LoginUserDto.php" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/src/app/User/Application/Dto/RegisterUserDto.php" beforeDir="false" afterPath="$PROJECT_DIR$/src/app/User/Application/Dto/RegisterUserDto.php" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/src/app/User/Application/Dto/ShowUserDto.php" beforeDir="false" afterPath="$PROJECT_DIR$/src/app/User/Application/Dto/ShowUserDto.php" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/src/app/User/Application/Dto/UpdateUserDto.php" beforeDir="false" afterPath="$PROJECT_DIR$/src/app/User/Application/Dto/UpdateUserDto.php" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/src/app/User/Application/Factory/RegisterUserDtoFactory.php" beforeDir="false" afterPath="$PROJECT_DIR$/src/app/User/Application/Factory/RegisterUserDtoFactory.php" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/src/app/User/Application/UseCase/LogoutUserUseCase.php" beforeDir="false" afterPath="$PROJECT_DIR$/src/app/User/Application/UseCase/LogoutUserUseCase.php" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/src/app/User/Application/UseCase/ShowUserUseCase.php" beforeDir="false" afterPath="$PROJECT_DIR$/src/app/User/Application/UseCase/ShowUserUseCase.php" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/src/app/User/Domain/Entity/UserEntity.php" beforeDir="false" afterPath="$PROJECT_DIR$/src/app/User/Domain/Entity/UserEntity.php" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/src/app/User/Domain/Factory/UserEntityFactory.php" beforeDir="false" afterPath="$PROJECT_DIR$/src/app/User/Domain/Factory/UserEntityFactory.php" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/src/app/User/Domain/Factory/UserFromModelEntityFactory.php" beforeDir="false" afterPath="$PROJECT_DIR$/src/app/User/Domain/Factory/UserFromModelEntityFactory.php" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/src/app/User/Domain/Factory/UserUpdateEntityFactory.php" beforeDir="false" afterPath="$PROJECT_DIR$/src/app/User/Domain/Factory/UserUpdateEntityFactory.php" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/src/app/User/Domain/RepositoryInterface/UserRepositoryInterface.php" beforeDir="false" afterPath="$PROJECT_DIR$/src/app/User/Domain/RepositoryInterface/UserRepositoryInterface.php" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/src/app/User/Infrastructure/InfrastructureTest/GenerateTokenServiceTest.php" beforeDir="false" afterPath="$PROJECT_DIR$/src/app/User/Infrastructure/InfrastructureTest/GenerateTokenServiceTest.php" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/src/app/User/Infrastructure/InfrastructureTest/JwtAuthServiceTest.php" beforeDir="false" afterPath="$PROJECT_DIR$/src/app/User/Infrastructure/InfrastructureTest/JwtAuthServiceTest.php" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/src/app/User/Infrastructure/InfrastructureTest/UserRepository_findByIdTest.php" beforeDir="false" afterPath="$PROJECT_DIR$/src/app/User/Infrastructure/InfrastructureTest/UserRepository_findByIdTest.php" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/src/app/User/Infrastructure/InfrastructureTest/UserRepository_updateTest.php" beforeDir="false" afterPath="$PROJECT_DIR$/src/app/User/Infrastructure/InfrastructureTest/UserRepository_updateTest.php" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/src/app/User/Infrastructure/Repository/UserRepository.php" beforeDir="false" afterPath="$PROJECT_DIR$/src/app/User/Infrastructure/Repository/UserRepository.php" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/src/app/User/Presentation/PresentationTest/Controller/UserController_logoutTest.php" beforeDir="false" afterPath="$PROJECT_DIR$/src/app/User/Presentation/PresentationTest/Controller/UserController_logoutTest.php" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/src/app/User/Presentation/PresentationTest/Controller/UserController_registerTest.php" beforeDir="false" afterPath="$PROJECT_DIR$/src/app/User/Presentation/PresentationTest/Controller/UserController_registerTest.php" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/src/app/User/Presentation/PresentationTest/Controller/UserController_showTest.php" beforeDir="false" afterPath="$PROJECT_DIR$/src/app/User/Presentation/PresentationTest/Controller/UserController_showTest.php" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/src/app/User/Presentation/PresentationTest/Controller/UserController_updateTest.php" beforeDir="false" afterPath="$PROJECT_DIR$/src/app/User/Presentation/PresentationTest/Controller/UserController_updateTest.php" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/src/app/User/Presentation/PresentationTest/RegisterUserViewModelFactoryTest.php" beforeDir="false" afterPath="$PROJECT_DIR$/src/app/User/Presentation/PresentationTest/RegisterUserViewModelFactoryTest.php" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/src/app/User/Presentation/PresentationTest/ShowUserViewModelTest.php" beforeDir="false" afterPath="$PROJECT_DIR$/src/app/User/Presentation/PresentationTest/ShowUserViewModelTest.php" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/src/app/User/Presentation/PresentationTest/UpdateUserViewModelTest.php" beforeDir="false" afterPath="$PROJECT_DIR$/src/app/User/Presentation/PresentationTest/UpdateUserViewModelTest.php" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/app/Post/Infrastructure/Repository/PostRepository.php" beforeDir="false" afterPath="$PROJECT_DIR$/src/app/Post/Infrastructure/Repository/PostRepository.php" afterDir="false" />
     </list>
     <option name="SHOW_DIALOG" value="false" />
     <option name="HIGHLIGHT_CONFLICTS" value="true" />
@@ -193,7 +163,7 @@
     "PHPUnit.メイン.executor": "Run",
     "RunOnceActivity.ShowReadmeOnStart": "true",
     "RunOnceActivity.git.unshallow": "true",
-    "git-widget-placeholder": "feature/modify-namespace-user-id",
+    "git-widget-placeholder": "feture/edit-post-infra-repository",
     "node.js.detected.package.eslint": "true",
     "node.js.selected.package.eslint": "(autodetect)",
     "nodejs_package_manager_path": "npm",

--- a/src/app/Post/Infrastructure/InfrastructureTest/EditPostRepositoryTest.php
+++ b/src/app/Post/Infrastructure/InfrastructureTest/EditPostRepositoryTest.php
@@ -1,0 +1,150 @@
+<?php
+
+namespace App\Post\Infrastructure\InfrastructureTest;
+
+use App\Post\Domain\EntityFactory\EditPostEntityFactory;
+use App\Post\Infrastructure\Repository\PostRepository;
+use Tests\TestCase;
+use Mockery;
+use App\Post\Domain\Entity\PostEntity;
+use App\Post\Domain\EntityFactory\PostFromModelEntityFactory;
+use App\Common\Domain\Enum\PostVisibility as PostVisibilityEnum;
+use App\Post\Domain\RepositoryInterface\PostRepositoryInterface;
+use App\Common\Domain\ValueObject\PostId;
+use App\Common\Domain\ValueObject\UserId;
+use App\Post\Domain\ValueObject\Postvisibility;
+use Illuminate\Support\Facades\DB;
+use App\Models\Post;
+use App\Models\User;
+
+class EditPostRepositoryTest extends TestCase
+{
+    private $repository;
+    private $userId;
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->refresh();
+        $this->repository = new PostRepository(
+            new Post(),
+        );
+        $this->userId = $this->createUser();
+        $this->createFirstPost();
+    }
+
+    protected function tearDown(): void
+    {
+        $this->refresh();
+        parent::tearDown();
+    }
+
+    private function refresh(): void
+    {
+        if (env('APP_ENV') === 'testing') {
+            DB::connection('mysql')->statement('SET FOREIGN_KEY_CHECKS=0;');
+            Post::truncate();
+            User::truncate();
+            DB::connection('mysql')->statement('SET FOREIGN_KEY_CHECKS=1;');
+        }
+    }
+
+    private function createUser(): int
+    {
+        return User::create([
+            'first_name' => 'bruno',
+            'last_name' => 'fernandes',
+            'email' => 'manchester-8@test.com',
+            'password' => 'test1234',
+            'bio' => 'football player',
+            'location' => 'Manchester',
+            'skills' => ['Laravel', 'React'],
+            'profile_image' => 'https://example.com/profile.jpg',
+        ])->id;
+    }
+
+    private function createFirstPost(): void
+    {
+        Post::create([
+            'user_id' => $this->userId,
+            'content' => 'Manchester United wins the Premier League in 2025',
+            'media_path' => 'https://example.com/media.jpg',
+            'visibility' => 'private',
+        ]);
+    }
+
+    private function mockEntity(): PostEntity
+    {
+        $factory = Mockery::mock(
+            'alias' . EditPostEntityFactory::class
+        );
+
+        $entity = Mockery::mock(PostEntity::class);
+
+        $factory
+            ->shouldReceive('build')
+            ->andReturn($entity);
+
+        $entity
+            ->shouldReceive('getId')
+            ->andReturn(new PostId($this->updateData()['id']));
+
+        $entity
+            ->shouldReceive('getUserId')
+            ->andReturn(new UserId($this->userId));
+
+        $entity
+            ->shouldReceive('getContent')
+            ->andReturn($this->updateData()['content']);
+
+        $entity
+            ->shouldReceive('getMediaPath')
+            ->andReturn($this->updateData()['mediaPath']);
+
+        $entity
+            ->shouldReceive('getPostVisibility')
+            ->andReturn(new Postvisibility(PostVisibilityEnum::fromString($this->updateData()['visibility'])));
+
+        return $entity;
+    }
+
+    private function updateData(): array
+    {
+        $updateData = [
+            'id' => 1,
+            'userId' => $this->userId,
+            'content' => 'Updated content for the post',
+            'mediaPath' => 'https://example.com/updated_media.jpg',
+            'visibility' => 'public',
+        ];
+
+        return $updateData;
+    }
+
+    public function test_edit_user_post_check_type(): void
+    {
+        $result = $this->repository->editById(
+            $this->mockEntity()
+        );
+
+        $this->assertInstanceOf(PostEntity::class, $result);
+    }
+
+    public function test_edit_user_post_check_value(): void
+    {
+        $result = $this->repository->editById(
+            $this->mockEntity()
+        );
+
+        $this->assertDatabaseHas(
+            'posts',
+            [
+                'id' => $this->updateData()['id'],
+                'user_id' => $this->userId,
+                'content' => $this->updateData()['content'],
+                'media_path' => $this->updateData()['mediaPath'],
+                'visibility' => PostVisibilityEnum::fromString($this->updateData()['visibility'])->toInt(),
+            ],
+            'mysql'
+        );
+    }
+}

--- a/src/app/Post/Infrastructure/Repository/PostRepository.php
+++ b/src/app/Post/Infrastructure/Repository/PostRepository.php
@@ -6,6 +6,7 @@ use App\Post\Domain\RepositoryInterface\PostRepositoryInterface;
 use App\Models\Post;
 use App\Post\Domain\Entity\PostEntity;
 use App\Post\Domain\EntityFactory\PostFromModelEntityFactory;
+use Exception;
 
 class PostRepository implements PostRepositoryInterface
 {
@@ -23,5 +24,25 @@ class PostRepository implements PostRepositoryInterface
         ])->toArray();
 
         return PostFromModelEntityFactory::build($newPost);
+    }
+
+    public function editById(PostEntity $entity): PostEntity
+    {
+        $targetPost = $this->post
+            ->where('id', $entity->getId()?->getValue())
+            ->where('user_id', $entity->getUserId()->getValue())
+            ->first();
+
+        if (is_null($targetPost)) {
+            throw new Exception('The post could not be found or edited.');
+        }
+
+        $targetPost->fill([
+            'content' => $entity->getContent(),
+            'media_path' => $entity->getMediaPath(),
+            'visibility' => $entity->getPostVisibility()->getValue(),
+        ])->save();
+
+        return PostFromModelEntityFactory::build($targetPost->toArray());
     }
 }


### PR DESCRIPTION
### Description

This pull request introduces the `editById` method to the Infrastructure layer, allowing posts to be updated directly through the repository.

The method ensures:
- It fetches the target post using both `id` and `user_id` to ensure ownership.
- It updates the fields: `content`, `media_path`, and `visibility`.
- It returns a fresh `PostEntity` using `PostFromModelEntityFactory`.
- It throws an exception if the post cannot be found, enforcing strict control.