### PR TITLE
Add EditPostDto for wrapping PostEntity with accessor methods

### DIFF
--- a/src/app/Post/Application/ApplicationTest/EditPostDtoTest.php
+++ b/src/app/Post/Application/ApplicationTest/EditPostDtoTest.php
@@ -1,0 +1,84 @@
+<?php
+
+namespace App\Post\Application\ApplicationTest;
+
+use App\Common\Domain\Enum\PostVisibility as PostVisibilityEnum;
+use App\Common\Domain\ValueObject\UserId;
+use App\Post\Domain\ValueObject\Postvisibility;
+use Tests\TestCase;
+use App\Post\Application\Dto\EditPostDto;
+use App\Post\Domain\Entity\PostEntity;
+use Mockery;
+use App\Common\Domain\ValueObject\PostId;
+
+class EditPostDtoTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+    }
+
+    protected function tearDown(): void
+    {
+        parent::tearDown();
+    }
+
+    private function arrayData(): array
+    {
+        return [
+            'id' => 1,
+            'userId' => 1,
+            'content' => 'Updated content',
+            'mediaPath' => 'https://example.com/updated_media.jpg',
+            'visibility' => 'public',
+        ];
+    }
+
+    private function mockEntity(): PostEntity
+    {
+        $entity = Mockery::mock(PostEntity::class);
+
+        $entity
+            ->shouldReceive('getId')
+            ->andReturn(new PostId($this->arrayData()['id']));
+
+        $entity
+            ->shouldReceive('getUserId')
+            ->andReturn(new UserId(1));
+
+        $entity
+            ->shouldReceive('getContent')
+            ->andReturn($this->arrayData()['content']);
+
+        $entity
+            ->shouldReceive('getMediaPath')
+            ->andReturn($this->arrayData()['mediaPath']);
+
+        $entity
+            ->shouldReceive('getPostVisibility')
+            ->andReturn(new Postvisibility(PostVisibilityEnum::fromString($this->arrayData()['visibility'])));
+
+        return $entity;
+    }
+
+    public function test_dto_check_type(): void
+    {
+        $result = new EditPostDto($this->mockEntity());
+
+        $this->assertInstanceOf(EditPostDto::class, $result);
+    }
+
+    public function test_dto_check_value(): void
+    {
+        $dto = new EditPostDto($this->mockEntity());
+
+        $this->assertEquals(1, $dto->getId()->getValue());
+        $this->assertEquals(1, $dto->getUserid()->getValue());
+        $this->assertEquals('Updated content', $dto->getContent());
+        $this->assertEquals('https://example.com/updated_media.jpg', $dto->getMediaPath());
+        $this->assertEquals(
+            new Postvisibility(PostVisibilityEnum::fromString($this->arrayData()['visibility'])),
+            $dto->getVisibility()
+        );
+    }
+}

--- a/src/app/Post/Application/Dto/EditPostDto.php
+++ b/src/app/Post/Application/Dto/EditPostDto.php
@@ -1,0 +1,58 @@
+<?php
+
+namespace App\Post\Application\Dto;
+
+use App\Common\Domain\ValueObject\PostId;
+use App\Common\Domain\ValueObject\UserId;
+use App\Post\Domain\Entity\PostEntity;
+use App\Post\Domain\ValueObject\Postvisibility;
+
+class EditPostDto
+{
+    public function __construct(
+        public readonly PostEntity $entity,
+    ) {
+    }
+
+    public function getId(): PostId
+    {
+        return $this->entity->getId();
+    }
+
+    public function getUserid(): UserId
+    {
+        return $this->entity->getUserId();
+    }
+
+    public function getContent(): string
+    {
+        return $this->entity->getContent();
+    }
+
+    public function getMediaPath(): ?string
+    {
+        return $this->entity->getMediaPath();
+    }
+
+    public function getVisibility(): PostVisibility
+    {
+        return $this->entity->getPostVisibility();
+    }
+
+    public function toArray(): array
+    {
+        return [
+            'userId' => $this->getUserid()->getValue(),
+            'content' => $this->getContent(),
+            'mediaPath' => $this->getMediaPath(),
+            'visibility' => $this->getVisibility()->getValue(),
+        ];
+    }
+
+    public static function build(PostEntity $entity): EditPostDto
+    {
+        return new EditPostDto(
+            entity: $entity
+        );
+    }
+}


### PR DESCRIPTION
### Description

This PR introduces `EditPostDto`, a Data Transfer Object that encapsulates a `PostEntity` and exposes value accessors and serialization via `toArray()`.

### Why

Instead of directly passing a domain entity through the Application layer, wrapping it inside a dedicated DTO allows for clearer data boundaries, transformation logic, and future-proofing (e.g., formatting, derived values, or flattening nested structures).

### How

- Added `EditPostDto` class:
  - Wraps `PostEntity` via constructor.
  - Provides read-only accessors (`getId`, `getUserId`, `getContent`, etc.).
  - Implements `toArray()` to export flattened primitive values.
- Added static `build()` factory method for clarity and testability.
