### PR TITLE
Add Application layer structure for editing posts: UseCommand, UseCase, and Dto

### DIFF
--- a/src/app/Post/Application/ApplicationTest/EditPostDtoTest.php
+++ b/src/app/Post/Application/ApplicationTest/EditPostDtoTest.php
@@ -1,0 +1,84 @@
+<?php
+
+namespace App\Post\Application\ApplicationTest;
+
+use App\Common\Domain\Enum\PostVisibility as PostVisibilityEnum;
+use App\Common\Domain\ValueObject\UserId;
+use App\Post\Domain\ValueObject\Postvisibility;
+use Tests\TestCase;
+use App\Post\Application\Dto\EditPostDto;
+use App\Post\Domain\Entity\PostEntity;
+use Mockery;
+use App\Common\Domain\ValueObject\PostId;
+
+class EditPostDtoTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+    }
+
+    protected function tearDown(): void
+    {
+        parent::tearDown();
+    }
+
+    private function arrayData(): array
+    {
+        return [
+            'id' => 1,
+            'userId' => 1,
+            'content' => 'Updated content',
+            'mediaPath' => 'https://example.com/updated_media.jpg',
+            'visibility' => 'public',
+        ];
+    }
+
+    private function mockEntity(): PostEntity
+    {
+        $entity = Mockery::mock(PostEntity::class);
+
+        $entity
+            ->shouldReceive('getId')
+            ->andReturn(new PostId($this->arrayData()['id']));
+
+        $entity
+            ->shouldReceive('getUserId')
+            ->andReturn(new UserId(1));
+
+        $entity
+            ->shouldReceive('getContent')
+            ->andReturn($this->arrayData()['content']);
+
+        $entity
+            ->shouldReceive('getMediaPath')
+            ->andReturn($this->arrayData()['mediaPath']);
+
+        $entity
+            ->shouldReceive('getPostVisibility')
+            ->andReturn(new Postvisibility(PostVisibilityEnum::fromString($this->arrayData()['visibility'])));
+
+        return $entity;
+    }
+
+    public function test_dto_check_type(): void
+    {
+        $result = new EditPostDto($this->mockEntity());
+
+        $this->assertInstanceOf(EditPostDto::class, $result);
+    }
+
+    public function test_dto_check_value(): void
+    {
+        $dto = new EditPostDto($this->mockEntity());
+
+        $this->assertEquals(1, $dto->getId()->getValue());
+        $this->assertEquals(1, $dto->getUserid()->getValue());
+        $this->assertEquals('Updated content', $dto->getContent());
+        $this->assertEquals('https://example.com/updated_media.jpg', $dto->getMediaPath());
+        $this->assertEquals(
+            new Postvisibility(PostVisibilityEnum::fromString($this->arrayData()['visibility'])),
+            $dto->getVisibility()
+        );
+    }
+}

--- a/src/app/Post/Application/ApplicationTest/EditPostUseCaseTest.php
+++ b/src/app/Post/Application/ApplicationTest/EditPostUseCaseTest.php
@@ -1,0 +1,147 @@
+<?php
+
+namespace App\Post\Application\ApplicationTest;
+
+use App\Common\Domain\Enum\PostVisibility as PostVisibilityEnum;
+use App\Common\Domain\ValueObject\PostId;
+use App\Common\Domain\ValueObject\UserId;
+use App\Post\Domain\Entity\PostEntity;
+use App\Post\Domain\ValueObject\Postvisibility;
+use Tests\TestCase;
+use App\Post\Application\UseCase\EditUseCase;
+use Mockery;
+use App\Post\Application\UseCommand\EditPostUseCommand;
+use App\Post\Domain\RepositoryInterface\PostRepositoryInterface;
+use App\Post\Application\Dto\EditPostDto;
+
+class EditPostUseCaseTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+    }
+
+    protected function tearDown(): void
+    {
+        parent::tearDown();
+    }
+
+    private function arrayData(): array
+    {
+        return [
+            'id' => 1,
+            'userId' => 1,
+            'content' => 'Updated content',
+            'mediaPath' => 'https://example.com/updated_media.jpg',
+            'visibility' => 'public',
+        ];
+    }
+
+    private function mockEntity(): PostEntity
+    {
+        $entity = Mockery::mock(PostEntity::class);
+
+        $entity
+            ->shouldReceive('getId')
+            ->andReturn(new PostId($this->arrayData()['id']));
+
+        $entity
+            ->shouldReceive('getUserId')
+            ->andReturn(new UserId(1));
+
+        $entity
+            ->shouldReceive('getContent')
+            ->andReturn($this->arrayData()['content']);
+
+        $entity
+            ->shouldReceive('getMediaPath')
+            ->andReturn($this->arrayData()['mediaPath']);
+
+        $entity
+            ->shouldReceive('getPostVisibility')
+            ->andReturn(new Postvisibility(PostVisibilityEnum::fromString($this->arrayData()['visibility'])));
+
+        return $entity;
+    }
+
+    private function mockUseCommand(): EditPostUseCommand
+    {
+        $command = Mockery::mock(EditPostUseCommand::class);
+
+        $command
+            ->shouldReceive('getId')
+            ->andReturn($this->arrayData()['id']);
+
+        $command
+            ->shouldReceive('getUserId')
+            ->andReturn($this->arrayData()['userId']);
+
+        $command
+            ->shouldReceive('getContent')
+            ->andReturn($this->arrayData()['content']);
+
+        $command
+            ->shouldReceive('getMediaPath')
+            ->andReturn($this->arrayData()['mediaPath']);
+
+        $command
+            ->shouldReceive('getVisibility')
+            ->andReturn(new Postvisibility(PostVisibilityEnum::fromString($this->arrayData()['visibility'])));
+
+        $command
+            ->shouldReceive('toArray')
+            ->andReturn($this->arrayData());
+
+        return $command;
+    }
+
+    private function mockDto(): EditPostDto
+    {
+        $dto = Mockery::mock(EditPostDto::class);
+
+        $dto
+            ->shouldReceive('getId')
+            ->andReturn(new PostId($this->arrayData()['id']));
+
+        $dto
+            ->shouldReceive('getUserId')
+            ->andReturn(new UserId(1));
+
+        $dto
+            ->shouldReceive('getContent')
+            ->andReturn($this->arrayData()['content']);
+
+        $dto
+            ->shouldReceive('getMediaPath')
+            ->andReturn($this->arrayData()['mediaPath']);
+
+        $dto
+            ->shouldReceive('getVisibility')
+            ->andReturn(new Postvisibility(PostVisibilityEnum::fromString($this->arrayData()['visibility'])));
+
+        return $dto;
+    }
+
+    private function mockRepository(): PostRepositoryInterface
+    {
+        $repository = Mockery::mock(PostRepositoryInterface::class);
+
+        $repository
+            ->shouldReceive('editById')
+            ->with(Mockery::type(PostEntity::class))
+            ->andReturn($this->mockEntity());
+
+        return $repository;
+    }
+
+    public function test_use_case(): void
+    {
+        $useCase = new EditUseCase(
+            $this->mockRepository()
+        );
+
+        $result = $useCase->handle($this->mockUseCommand());
+
+        $this->assertInstanceOf(EditPostDto::class, $result);
+    }
+}

--- a/src/app/Post/Application/ApplicationTest/EditPostUseCommandTest.php
+++ b/src/app/Post/Application/ApplicationTest/EditPostUseCommandTest.php
@@ -1,0 +1,66 @@
+<?php
+
+namespace App\Post\Application\ApplicationTest;
+
+use Tests\TestCase;
+use InvalidArgumentException;
+use App\Post\Application\UseCommand\EditPostUseCommand;
+
+class EditPostUseCommandTest extends TestCase
+{
+    private int $userId;
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->userId = 1;
+    }
+
+    protected function tearDown(): void
+    {
+        parent::tearDown();
+    }
+
+    private function requestData(): array
+    {
+        return [
+            'id' => 1,
+            'userId' => $this->userId,
+            'content' => 'Updated content',
+            'mediaPath' => 'https://example.com/updated_media.jpg',
+            'visibility' => 'public',
+        ];
+    }
+
+    public function test_check_use_command_type(): void
+    {
+        $useCommand = EditPostUseCommand::build($this->requestData());
+
+        $this->assertInstanceOf(EditPostUseCommand::class, $useCommand);
+    }
+
+    public function test_check_use_command_value(): void
+    {
+        $useCommand = EditPostUseCommand::build($this->requestData());
+
+        $this->assertEquals(1, $useCommand->toArray()['id']);
+        $this->assertEquals($this->userId, $useCommand->toArray()['userId']);
+        $this->assertEquals('Updated content', $useCommand->toArray()['content']);
+        $this->assertEquals('https://example.com/updated_media.jpg', $useCommand->toArray()['mediaPath']);
+        $this->assertEquals('public', $useCommand->toArray()['visibility']);
+    }
+
+    public function test_invalid_use_command_request(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+
+        $invalidData = [
+            'id' => 1,
+            'userId' => $this->userId,
+            // 'content' is missing
+            'mediaPath' => 'https://example.com/updated_media.jpg',
+            'visibility' => 'public',
+        ];
+
+        EditPostUseCommand::build($invalidData);
+    }
+}

--- a/src/app/Post/Application/Dto/EditPostDto.php
+++ b/src/app/Post/Application/Dto/EditPostDto.php
@@ -1,0 +1,58 @@
+<?php
+
+namespace App\Post\Application\Dto;
+
+use App\Common\Domain\ValueObject\PostId;
+use App\Common\Domain\ValueObject\UserId;
+use App\Post\Domain\Entity\PostEntity;
+use App\Post\Domain\ValueObject\Postvisibility;
+
+class EditPostDto
+{
+    public function __construct(
+        public readonly PostEntity $entity,
+    ) {
+    }
+
+    public function getId(): PostId
+    {
+        return $this->entity->getId();
+    }
+
+    public function getUserid(): UserId
+    {
+        return $this->entity->getUserId();
+    }
+
+    public function getContent(): string
+    {
+        return $this->entity->getContent();
+    }
+
+    public function getMediaPath(): ?string
+    {
+        return $this->entity->getMediaPath();
+    }
+
+    public function getVisibility(): PostVisibility
+    {
+        return $this->entity->getPostVisibility();
+    }
+
+    public function toArray(): array
+    {
+        return [
+            'userId' => $this->getUserid()->getValue(),
+            'content' => $this->getContent(),
+            'mediaPath' => $this->getMediaPath(),
+            'visibility' => $this->getVisibility()->getValue(),
+        ];
+    }
+
+    public static function build(PostEntity $entity): EditPostDto
+    {
+        return new EditPostDto(
+            entity: $entity
+        );
+    }
+}

--- a/src/app/Post/Application/UseCase/EditUseCase.php
+++ b/src/app/Post/Application/UseCase/EditUseCase.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace App\Post\Application\UseCase;
+
+use App\Post\Domain\RepositoryInterface\PostRepositoryInterface;
+use App\Post\Application\Dto\EditPostDto;
+use App\Post\Application\UseCommand\EditPostUseCommand;
+use App\Post\Domain\Entity\PostEntity;
+
+class EditUseCase
+{
+    public function __construct(
+        private readonly PostRepositoryInterface $repository
+    ) {}
+
+    public function handle(
+        EditPostUseCommand $command
+    ): EditPostDto {
+        $entity = PostEntity::build(
+            $command->toArray()
+        );
+
+        $this->repository->editById($entity);
+
+        return EditPostDto::build(
+            $entity
+        );
+    }
+}

--- a/src/app/Post/Application/UseCommand/EditPostUseCommand.php
+++ b/src/app/Post/Application/UseCommand/EditPostUseCommand.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace App\Post\Application\UseCommand;
+
+use InvalidArgumentException;
+
+class EditPostUseCommand
+{
+    public function __construct(
+        private readonly int $id,
+        private readonly int $userId,
+        private readonly string $content,
+        private readonly ?string $mediaPath,
+        private readonly string $visibility
+    ) {}
+
+    private static $requiredProperties = [
+        'id',
+        'userId',
+        'content',
+        'visibility'
+    ];
+
+    private static function validate(array $data): void
+    {
+        foreach (self::$requiredProperties as $property) {
+            if (!array_key_exists($property, $data)) {
+                throw new InvalidArgumentException("Missing required property: {$property}");
+            }
+        }
+    }
+
+    public static function build(array $request): self
+    {
+        self::validate($request);
+
+        return new self(
+            id: $request['id'],
+            userId: $request['userId'],
+            content: $request['content'],
+            mediaPath: $request['mediaPath'] ?? null,
+            visibility: $request['visibility']
+        );
+    }
+
+    public function toArray(): array
+    {
+        return [
+            'id' => $this->id,
+            'userId' => $this->userId,
+            'content' => $this->content,
+            'mediaPath' => $this->mediaPath,
+            'visibility' => $this->visibility
+        ];
+    }
+}


### PR DESCRIPTION
### Description

This PR introduces the full application-layer structure for editing a post, including:

- `EditPostUseCommand`: a data carrier encapsulating primitive request values.
- `EditUseCase`: the orchestrator responsible for transforming command → entity, delegating persistence to repository, and returning a DTO.
- `EditPostDto`: a value-mapping wrapper exposing flattened entity data for output.

### Why

Following the layered architecture, the Application layer should coordinate input parsing, domain logic delegation, and output serialization. This separation promotes testability, explicit flow, and domain integrity.

By introducing all three components in alignment, we ensure consistency across layers and clarity of responsibility.

### How

- `EditPostUseCommand`:
  - Static `build(array)` constructor with validation of required keys.
  - Immutable primitive data holder.
- `EditUseCase`:
  - Accepts the command, transforms it into a `PostEntity` via `PostEntity::build()`.
  - Calls `editById()` on `PostRepositoryInterface`.
  - Returns `EditPostDto::build()` wrapping the resulting entity.
- `EditPostDto`:
  - Exposes read-only accessors for id, userId, content, mediaPath, and visibility.
  - Provides a `toArray()` method for controller/view layer consumption.

