### PR TITLE
Add EditPostViewModel to transform EditPostDto for presentation layer

### DIFF
--- a/src/app/Post/Presentation/PresentationTest/EditPostViewModelTest.php
+++ b/src/app/Post/Presentation/PresentationTest/EditPostViewModelTest.php
@@ -1,0 +1,84 @@
+<?php
+
+namespace App\Post\Presentation\PresentationTest;
+
+use Mockery;
+use App\Post\Application\Dto\EditPostDto;
+use App\Post\Presentation\ViewModel\EditPostViewModel;
+use Tests\TestCase;
+use App\Post\Domain\ValueObject\Postvisibility;
+use App\Common\Domain\Enum\PostVisibility as EnumPostVisibility;
+use App\Common\Domain\ValueObject\PostId;
+use App\Common\Domain\ValueObject\UserId;
+
+class EditPostViewModelTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+    }
+
+    protected function tearDown(): void
+    {
+        parent::tearDown();
+    }
+
+    private function arrayData(): array
+    {
+        return [
+            'id' => 1,
+            'userId' => 1,
+            'content' => 'Updated content',
+            'mediaPath' => 'https://example.com/updated_media.jpg',
+            'visibility' => 'public',
+        ];
+    }
+
+    private function mockDto(): EditPostDto
+    {
+        $dto = Mockery::mock(EditPostDto::class);
+
+        $dto
+            ->shouldReceive('getId')
+            ->andReturn(new PostId($this->arrayData()['id']));
+
+        $dto
+            ->shouldReceive('getUserid')
+            ->andReturn(new UserId($this->arrayData()['userId']));
+
+        $dto
+            ->shouldReceive('getContent')
+            ->andReturn($this->arrayData()['content']);
+
+        $dto
+            ->shouldReceive('getMediaPath')
+            ->andReturn($this->arrayData()['mediaPath']);
+
+        $dto
+            ->shouldReceive('getVisibility')
+            ->andReturn(new Postvisibility(EnumPostVisibility::fromString($this->arrayData()['visibility'])));
+
+        return $dto;
+    }
+
+    public function test_view_model_check_type(): void
+    {
+        $result = new EditPostViewModel($this->mockDto());
+
+        $this->assertInstanceOf(EditPostViewModel::class, $result);
+    }
+
+    public function test_view_model_get_values(): void
+    {
+        $result = new EditPostViewModel($this->mockDto());
+
+        $this->assertEquals($this->arrayData()['id'], $result->toArray()['id']);
+        $this->assertEquals($this->arrayData()['userId'], $result->toArray()['userId']);
+        $this->assertEquals($this->arrayData()['content'], $result->toArray()['content']);
+        $this->assertEquals($this->arrayData()['mediaPath'], $result->toArray()['mediaPath']);
+        $this->assertEquals(
+            EnumPostVisibility::fromString($this->arrayData()['visibility'])->toLabel(),
+            $result->toArray()['visibility']
+        );
+    }
+}

--- a/src/app/Post/Presentation/ViewModel/EditPostViewModel.php
+++ b/src/app/Post/Presentation/ViewModel/EditPostViewModel.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace App\Post\Presentation\ViewModel;
+
+use App\Post\Application\Dto\EditPostDto;
+
+class EditPostViewModel
+{
+    public function __construct(
+        private readonly EditPostDto $dto,
+    ) {}
+
+    public function toArray(): array
+    {
+        return [
+            'id' => $this->dto->getId()->getValue(),
+            'userId' => $this->dto->getUserid()->getValue(),
+            'content' => $this->dto->getContent(),
+            'mediaPath' => $this->dto->getMediaPath(),
+            'visibility' => $this->dto->getVisibility()->getValue()->toLabel(),
+        ];
+    }
+}


### PR DESCRIPTION
### Description

This PR introduces `EditPostViewModel`, a presentation-layer class responsible for transforming an `EditPostDto` into a frontend-ready array format.

### Why

The ViewModel serves as a dedicated transformation layer between the application logic and the output format expected by the UI layer. By isolating this responsibility, we:

- Prevent leakage of domain objects or raw DTOs into the view
- Cleanly format complex value objects (e.g. visibility labels)
- Enable future enhancements such as localization, formatting, or data shaping without polluting the Application layer

### How

- Added `EditPostViewModel`:
  - Receives an `EditPostDto`
  - Provides `toArray()` output with:
    - Primitive values extracted via `getValue()`
    - Post visibility converted to user-facing label via `toLabel()`
- Added corresponding PHPUnit test:
  - Validates the shape and correctness of the returned array
  - Ensures transformation logic from ValueObjects is correctly applied
