### PR TITLE
Define interfaces for password reset token generation, notification dispatch, and request limitation

### DIFF
--- a/src/app/User/Domain/Service/PasswordResetNotificationServiceInterface.php
+++ b/src/app/User/Domain/Service/PasswordResetNotificationServiceInterface.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace App\User\Domain\Service;
+
+use App\Models\User;
+
+interface PasswordResetNotificationServiceInterface
+{
+    public function sendResetLink(User $user, string $token): void;
+}

--- a/src/app/User/Domain/Service/PasswordResetRequestLimitationServiceInterface.php
+++ b/src/app/User/Domain/Service/PasswordResetRequestLimitationServiceInterface.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace App\User\Domain\Service;
+
+use App\User\Domain\ValueObject\Email;
+
+interface PasswordResetRequestLimitationServiceInterface
+{
+    public function canRequestReset(Email $email): bool;
+}

--- a/src/app/User/Domain/Service/PasswordResetTokenServiceInterface.php
+++ b/src/app/User/Domain/Service/PasswordResetTokenServiceInterface.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace App\User\Domain\Service;
+
+use App\Models\User;
+
+interface PasswordResetTokenServiceInterface
+{
+    public function generateToken(User $user): string;
+}


### PR DESCRIPTION
###Description

This pull request introduces three domain service interfaces for the password reset request use case.

- `PasswordResetTokenServiceInterface`: generates a unique password reset token
- `PasswordResetRequestLimitationServiceInterface`: determines if a reset request is allowed based on timing
- `PasswordResetNotificationServiceInterface`: sends a reset link to the user

These interfaces are defined under `App\User\Domain\PasswordReset`.