### PR TITLE
Add PasswordRequestEntity and related value objects for password reset domain

### DIFF
--- a/src/app/Common/Domain/ValueObject/ExpiredAt.php
+++ b/src/app/Common/Domain/ValueObject/ExpiredAt.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace App\Common\Domain\ValueObject;
+
+use DateTimeImmutable;
+use InvalidArgumentException;
+
+
+class ExpiredAt
+{
+    private DateTimeImmutable $value;
+
+    public function __construct(DateTimeImmutable $value)
+    {
+        if ($value < new DateTimeImmutable()) {
+            throw new InvalidArgumentException('Expiration date must be in the future.');
+        }
+
+        $this->value = $value;
+    }
+
+    public function getValue(): DateTimeImmutable
+    {
+        return $this->value;
+    }
+
+    public function isExpired(?DateTimeImmutable $now = null): bool
+    {
+        $now ??= new DateTimeImmutable();
+        return $now > $this->value;
+    }
+}

--- a/src/app/User/Domain/DomainTest/PasswordResetRequestTest.php
+++ b/src/app/User/Domain/DomainTest/PasswordResetRequestTest.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace App\User\Domain\DomainTest;
+
+use DateTimeImmutable;
+use Tests\TestCase;
+use App\User\Domain\Factory\PasswordRequestEntityFactory;
+use App\User\Domain\Entity\PasswordRequestEntity;
+use Illuminate\Support\Str;
+
+class PasswordResetRequestTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+    }
+
+    protected function tearDown(): void
+    {
+        parent::tearDown();
+    }
+
+    private function arrayData(): array
+    {
+        return [
+            'id' => 1,
+            'user_id' => 1,
+            'token' => Str::random(33),
+            'requested_at' => (new DateTimeImmutable())->format('Y-m-d H:i:s'),
+            'expired_at' => (new DateTimeImmutable('+1 hour'))->format('Y-m-d H:i:s'),
+        ];
+    }
+
+    public function test_check_entity_type(): void
+    {
+        $result = PasswordRequestEntityFactory::build($this->arrayData());
+
+        $this->assertInstanceOf(PasswordRequestEntity::class, $result);
+    }
+
+    public function test_check_entity_properties(): void
+    {
+        $result = PasswordRequestEntityFactory::build($this->arrayData());
+
+        $this->assertEquals($this->arrayData()['id'], $result->getId());
+        $this->assertEquals($this->arrayData()['user_id'], $result->getUserId()->getValue());
+        $this->assertSame(33, strlen($result->getToken()->getValue()));
+        $this->assertEquals($this->arrayData()['requested_at'], $result->getRequestedAt()->format('Y-m-d H:i:s'));
+        $this->assertEquals($this->arrayData()['expired_at'], $result->getExpiredAt()->getValue()->format('Y-m-d H:i:s'));
+    }
+}

--- a/src/app/User/Domain/Entity/PasswordRequestEntity.php
+++ b/src/app/User/Domain/Entity/PasswordRequestEntity.php
@@ -17,11 +17,7 @@ class PasswordRequestEntity
         private readonly DateTimeImmutable $requestedAt,
         private readonly ExpiredAt $expiredAt
     )
-    {
-        if (empty($this->token->getValue())) {
-            throw new InvalidArgumentException('Token cannot be empty.');
-        }
-    }
+    {}
 
     public function getId(): int
     {

--- a/src/app/User/Domain/Entity/PasswordRequestEntity.php
+++ b/src/app/User/Domain/Entity/PasswordRequestEntity.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace App\User\Domain\Entity;
+
+use App\Common\Domain\ValueObject\ExpiredAt;
+use App\Common\Domain\ValueObject\UserId;
+use App\User\Domain\ValueObject\PasswordResetToken;
+use DateTimeImmutable;
+use InvalidArgumentException;
+
+class PasswordRequestEntity
+{
+    public function __construct(
+        private readonly int $id,
+        private readonly UserId $userId,
+        private readonly PasswordResetToken $token,
+        private readonly DateTimeImmutable $requestedAt,
+        private readonly ExpiredAt $expiredAt
+    )
+    {
+        if (empty($this->token->getValue())) {
+            throw new InvalidArgumentException('Token cannot be empty.');
+        }
+    }
+
+    public function getId(): int
+    {
+        return $this->id;
+    }
+
+    public function getUserId(): UserId
+    {
+        return $this->userId;
+    }
+
+    public function getToken(): PasswordResetToken
+    {
+        return $this->token;
+    }
+
+    public function getRequestedAt(): DateTimeImmutable
+    {
+        return $this->requestedAt;
+    }
+
+    public function getExpiredAt(): ExpiredAt
+    {
+        return $this->expiredAt;
+    }
+
+    public function isExpired(?DateTimeImmutable $now = null): bool
+    {
+        return $this->expiredAt->isExpired($now);
+    }
+}

--- a/src/app/User/Domain/Factory/PasswordRequestEntityFactory.php
+++ b/src/app/User/Domain/Factory/PasswordRequestEntityFactory.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace App\User\Domain\Factory;
+
+use App\User\Domain\Entity\PasswordRequestEntity;
+use App\Common\Domain\ValueObject\UserId;
+use App\User\Domain\ValueObject\PasswordResetToken;
+use App\Common\Domain\ValueObject\ExpiredAt;
+use DateTimeImmutable;
+
+class PasswordRequestEntityFactory
+{
+    public static function build(array $data): PasswordRequestEntity
+    {
+        return new PasswordRequestEntity(
+            id: $data['id'],
+            userId: new UserId($data['user_id']),
+            token: new PasswordResetToken($data['token']),
+            requestedAt: new DateTimeImmutable($data['requested_at']),
+            expiredAt: new ExpiredAt(new DateTimeImmutable($data['expired_at']))
+        );
+    }
+}

--- a/src/app/User/Domain/ValueObject/PasswordResetToken.php
+++ b/src/app/User/Domain/ValueObject/PasswordResetToken.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace App\User\Domain\ValueObject;
+
+use InvalidArgumentException;
+
+final class PasswordResetToken
+{
+    private readonly string $value;
+    public function __construct(string $token)
+    {
+        if (strlen($token) < 32) {
+            throw new InvalidArgumentException('Token must be at least 32 characters long.');
+        }
+
+        $this->value = $token;
+    }
+
+    public function getValue(): string
+    {
+        return $this->value;
+    }
+}


### PR DESCRIPTION
### Description

This pull request introduces the `PasswordRequestEntity` to the domain layer, representing a password reset request as part of the user domain. The entity captures the following properties:

- `id`: Internal identifier
- `userId`: Wrapped in `UserId` value object
- `token`: Wrapped in `PasswordResetToken` value object
- `requestedAt`: Immutable timestamp
- `expiredAt`: Wrapped in `ExpiredAt` value object

The accompanying `PasswordRequestEntityFactory` is also added to create entities from primitive arrays (e.g. database records), ensuring all necessary value object transformations are handled.

Additionally, the following value objects are implemented:

- `PasswordResetToken`: Ensures token validity and minimum length
- `ExpiredAt`: Guarantees expiration is always a future time
- `UserId`: Wraps the user identifier in the domain context
