### PR TITLE
Add Eloquent model and migration for PasswordResetRequest entity

### DIFF
--- a/.idea/workspace.xml
+++ b/.idea/workspace.xml
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="AutoImportSettings">
+    <option name="autoReloadType" value="SELECTIVE" />
+  </component>
+  <component name="ChangeListManager">
+    <list default="true" id="49d63738-baf5-421d-afc1-b11a52726bbb" name="変更" comment="fix: test-environment-fix">
+      <change afterPath="$PROJECT_DIR$/src/app/Models/PasswordRequest.php" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/.idea/workspace.xml" beforeDir="false" afterPath="$PROJECT_DIR$/.idea/workspace.xml" afterDir="false" />
+    </list>
+    <option name="SHOW_DIALOG" value="false" />
+    <option name="HIGHLIGHT_CONFLICTS" value="true" />
+    <option name="HIGHLIGHT_NON_ACTIVE_CHANGELIST" value="false" />
+    <option name="LAST_RESOLUTION" value="IGNORE" />
+  </component>
+  <component name="ComposerSettings">
+    <execution />
+  </component>
+  <component name="Git.Settings">
+    <option name="RECENT_GIT_ROOT_PATH" value="$PROJECT_DIR$" />
+  </component>
+  <component name="PropertiesComponent"><![CDATA[{
+  "keyToString": {
+    "git-widget-placeholder": "feature/user-password-reset-migration__eloquent"
+  }
+}]]></component>
+  <component name="RunManager">
+    <configuration default="true" type="ComposerRunConfigurationType" factoryName="Composer Script">
+      <method v="2" />
+    </configuration>
+  </component>
+  <component name="VcsManagerConfiguration">
+    <MESSAGE value="fix: test-environment-fix" />
+    <option name="LAST_COMMIT_MESSAGE" value="fix: test-environment-fix" />
+  </component>
+  <component name="XSLT-Support.FileAssociations.UIState">
+    <expand />
+    <select />
+  </component>
+</project>

--- a/src/app/Models/User.php
+++ b/src/app/Models/User.php
@@ -63,4 +63,9 @@ class User extends Authenticatable
     {
         return $this->hasMany(Post::class);
     }
+
+    public function passwordResetRequests(): hasMany
+    {
+        return $this->hasMany(PasswordResetRequest::class);
+    }
 }


### PR DESCRIPTION
### Description

Introduced an Eloquent model and corresponding migration for managing password reset requests, as part of the password reset feature implementation.

### Details

- Created `PasswordResetRequest` model under `App\Models`.
- Defined fillable attributes for `user_id`, `token`, `requested_at`, and `expired_at`.
- Casted datetime fields to ensure correct date-time handling.
- Defined a `belongsTo` relationship to the `User` model.
- Created a migration to generate the `password_reset_requests` table with appropriate schema:
  - Primary key `id`
  - Foreign key `user_id` with `onDelete('cascade')`
  - Unique token
  - `requested_at` and `expired_at` as datetime fields
  - Standard `created_at` and `updated_at` timestamps
