### PR TITLE
Implement PasswordResetNotificationService with Mailable and unit test

### DIFF
--- a/src/app/User/Infrastructure/InfrastructureTest/Service/PasswordResetNotificationServiceTest.php
+++ b/src/app/User/Infrastructure/InfrastructureTest/Service/PasswordResetNotificationServiceTest.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace App\User\Infrastructure\InfrastructureTest\Service;
+
+use App\Models\User;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Mail;
+use Tests\TestCase;
+use App\User\Infrastructure\Service\PasswordResetNotificationService;
+use App\User\Infrastructure\Mail\PasswordResetNotification;
+
+class PasswordResetNotificationServiceTest extends TestCase
+{
+    private $userId;
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->refresh();
+        $this->userId = $this->createUser();
+    }
+
+    protected function tearDown(): void
+    {
+        $this->refresh();
+        parent::tearDown();
+    }
+
+    private function refresh(): void
+    {
+        if (env('APP_ENV') === 'testing') {
+            DB::connection('mysql')->statement('SET FOREIGN_KEY_CHECKS=0;');
+            User::truncate();
+            DB::connection('mysql')->statement('SET FOREIGN_KEY_CHECKS=1;');
+        }
+    }
+
+    private function createUser(): int
+    {
+        return User::create([
+            'first_name' => 'Sergio',
+            'last_name' => 'Ramos',
+            'email' => 'real-madrid15@test.com',
+            'password' => 'el-capitán-1234',
+            'bio' => 'Real Madrid player',
+            'location' => 'Madrid',
+            'skills' => ['Football', 'Leadership'],
+            'profile_image' => 'https://example.com/sergio.jpg'
+        ])->id;
+    }
+
+    public function test_sent_reset_link(): void
+    {
+        Mail::fake();
+
+        $user = User::find($this->userId);
+        $token = 'test-reset-token-123456';
+
+        $service = new PasswordResetNotificationService();
+        $service->sendResetLink($user, $token);
+
+        Mail::assertSent(PasswordResetNotification::class, function ($mail) use ($user, $token) {
+
+            return $mail->hasTo($user->email) &&
+                $mail->token === $token &&
+                $mail->envelope()->subject === 'Reset Your Password' &&
+                $mail->content()->view === 'emails.password_reset' &&
+                $mail->content()->with['resetUrl'] === url("/password-reset/{$token}");
+        });
+    }
+}

--- a/src/app/User/Infrastructure/Mail/PasswordResetNotification.php
+++ b/src/app/User/Infrastructure/Mail/PasswordResetNotification.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace App\User\Infrastructure\Mail;
+
+use Illuminate\Bus\Queueable;
+use Illuminate\Mail\Mailable;
+use Illuminate\Mail\Mailables\Content;
+use Illuminate\Mail\Mailables\Envelope;
+use Illuminate\Queue\SerializesModels;
+
+class PasswordResetNotification extends Mailable
+{
+    use Queueable, SerializesModels;
+    public function __construct(
+        public string $token
+    ) {}
+
+    public function envelope(): Envelope
+    {
+        return new Envelope(
+            subject: 'Reset Your Password',
+        );
+    }
+
+    public function content(): Content
+    {
+        return new Content(
+            view: 'emails.password_reset',
+            with: [
+                'resetUrl' => url("/password-reset/{$this->token}")
+            ]
+        );
+    }
+
+    public function attachments(): array
+    {
+        return [];
+    }
+}

--- a/src/app/User/Infrastructure/Service/PasswordResetNotificationService.php
+++ b/src/app/User/Infrastructure/Service/PasswordResetNotificationService.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace App\User\Infrastructure\Service;
+
+use App\Models\User;
+use Illuminate\Support\Facades\Mail;
+use App\User\Domain\Service\PasswordResetNotificationServiceInterface;
+use App\User\Infrastructure\Mail\PasswordResetNotification;
+
+class PasswordResetNotificationService implements PasswordResetNotificationServiceInterface
+{
+    public function sendResetLink(User $user, string $token): void
+    {
+        Mail::to($user->email)->send(new PasswordResetNotification($token));
+    }
+}

--- a/src/resources/views/emails/password_reset.blade.php
+++ b/src/resources/views/emails/password_reset.blade.php
@@ -1,0 +1,7 @@
+<p>You requested to reset your password.</p>
+
+<p>Click the link below to proceed:</p>
+
+<p><a href="{{ $resetUrl }}">{{ $resetUrl }}</a></p>
+
+<p>This link will expire in 1 hour.</p>


### PR DESCRIPTION
### Description

This PR implements `PasswordResetNotificationService`, which sends a password reset email via a domain-defined interface.

It also defines the Mailable class `PasswordResetNotification` using the new Laravel `envelope()` / `content()` structure, and includes a unit test using `Mail::fake()` to verify delivery, contents, and token accuracy.

### Included:
- `PasswordResetNotificationService` implementing `PasswordResetNotificationServiceInterface`
- `PasswordResetNotification` (Mailable) with `envelope()` / `content()` methods
- Test: `PasswordResetNotificationServiceTest` to confirm email dispatch and content integrity
