### PR TITLE
Implement ThrottlePasswordResetRequestService and unit tests

### DIFF
--- a/src/app/User/Domain/Service/ThrottlePasswordResetRequestServiceInterface.php
+++ b/src/app/User/Domain/Service/ThrottlePasswordResetRequestServiceInterface.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace App\User\Domain\Service;
+
+use App\Models\User;
+
+interface ThrottlePasswordResetRequestServiceInterface
+{
+    public function checkThrottling(User $user): void;
+}

--- a/src/app/User/Infrastructure/InfrastructureTest/Service/ThrottlePasswordResetRequestServiceTest.php
+++ b/src/app/User/Infrastructure/InfrastructureTest/Service/ThrottlePasswordResetRequestServiceTest.php
@@ -1,0 +1,112 @@
+<?php
+
+namespace App\User\Infrastructure\InfrastructureTest\Service;
+
+use Symfony\Component\HttpKernel\Exception\TooManyRequestsHttpException;
+use Illuminate\Support\Facades\DB;
+use Tests\TestCase;
+use App\Models\User;
+use App\Models\PasswordResetRequest;
+use App\User\Infrastructure\Service\ThrottlePasswordResetRequestService;
+
+class ThrottlePasswordResetRequestServiceTest extends TestCase
+{
+    private $user;
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->refresh();
+        $this->user = $this->createUser();
+    }
+
+    protected function tearDown(): void
+    {
+        $this->refresh();
+        parent::tearDown();
+    }
+
+    private function refresh(): void
+    {
+        if (env('APP_ENV') === 'testing') {
+            DB::connection('mysql')->statement('SET FOREIGN_KEY_CHECKS=0;');
+            User::truncate();
+            PasswordResetRequest::truncate();
+            DB::connection('mysql')->statement('SET FOREIGN_KEY_CHECKS=1;');
+        }
+    }
+
+    private function createUser(): User
+    {
+        return User::create([
+            'first_name' => 'Sergio',
+            'last_name' => 'Ramos',
+            'email' => "real-madrid".rand(). "@test.com",
+            'password' => 'el-capitán-1234',
+            'bio' => 'Real Madrid player',
+            'location' => 'Madrid',
+            'skills' => ['Football', 'Leadership'],
+            'profile_image' => 'https://example.com/sergio.jpg'
+        ]);
+    }
+
+    public function test_throttle_password_request_correct_request(): void
+    {
+        for ($i = 0; $i < 3; $i++) {
+            PasswordResetRequest::create([
+                'user_id' => $this->user->id,
+                'token' => 'token-' . $i,
+                'requested_at' => now()->subMinutes(10),
+                'expired_at' => now()->addHour(),
+                'created_at' => now()->subMinutes(10),
+                'updated_at' => now()->subMinutes(10),
+            ]);
+        }
+
+
+        $service = new ThrottlePasswordResetRequestService();
+
+        $this->expectNotToPerformAssertions();
+        $service->checkThrottling($this->user);
+    }
+
+    public function test_throttle_password_request_incorrect_request(): void
+    {
+        for ($i = 0; $i < 6; $i++) {
+            PasswordResetRequest::create([
+                'user_id' => $this->user->id,
+                'token' => 'token-' . $i,
+                'requested_at' => now()->subMinutes(10),
+                'expired_at' => now()->addHour(),
+                'created_at' => now()->subMinutes(10),
+                'updated_at' => now()->subMinutes(10),
+            ]);
+        }
+
+        $this->expectException(TooManyRequestsHttpException::class);
+        $service = new ThrottlePasswordResetRequestService();
+
+        $service->checkThrottling($this->user);
+    }
+
+    public function test_throttle_password_request_wrong_user(): void
+    {
+        for ($i = 0; $i < 3; $i++) {
+            PasswordResetRequest::create([
+                'user_id' => $this->user->id,
+                'token' => 'token-' . $i,
+                'requested_at' => now()->subMinutes(10),
+                'expired_at' => now()->addHour(),
+                'created_at' => now()->subMinutes(10),
+                'updated_at' => now()->subMinutes(10),
+            ]);
+        }
+
+        $wrongUser = $this->createUser();
+
+        $service = new ThrottlePasswordResetRequestService();
+
+        $this->expectNotToPerformAssertions();
+
+        $service->checkThrottling($wrongUser);
+    }
+}

--- a/src/app/User/Infrastructure/Service/ThrottlePasswordResetRequestService.php
+++ b/src/app/User/Infrastructure/Service/ThrottlePasswordResetRequestService.php
@@ -14,12 +14,12 @@ class ThrottlePasswordResetRequestService implements ThrottlePasswordResetReques
 
     public function checkThrottling(User $user): void
     {
-        if (!$user->passwordResetRequests) {
+        if (!$user->passwordResetRequests()) {
             throw new InvalidArgumentException('User does not have password reset requests.');
         }
 
         $requests = $user
-            ->passwordResetRequests
+            ->passwordResetRequests()
             ->where('created_at', '>=', now()->subSeconds(self::TIME_FRAME))
             ->where('user_id', $user->id)
             ->count();

--- a/src/app/User/Infrastructure/Service/ThrottlePasswordResetRequestService.php
+++ b/src/app/User/Infrastructure/Service/ThrottlePasswordResetRequestService.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace App\User\Infrastructure\Service;
+
+use App\User\Domain\Service\ThrottlePasswordResetRequestServiceInterface;
+use App\Models\User;
+use InvalidArgumentException;
+use Symfony\Component\HttpKernel\Exception\TooManyRequestsHttpException;
+
+class ThrottlePasswordResetRequestService implements ThrottlePasswordResetRequestServiceInterface
+{
+    private const MAX_REQUESTS = 5;
+    private const TIME_FRAME = 3600;
+
+    public function checkThrottling(User $user): void
+    {
+        if (!$user->passwordResetRequests) {
+            throw new InvalidArgumentException('User does not have password reset requests.');
+        }
+
+        $requests = $user
+            ->passwordResetRequests
+            ->where('created_at', '>=', now()->subSeconds(self::TIME_FRAME))
+            ->where('user_id', $user->id)
+            ->count();
+
+        if ($requests >= self::MAX_REQUESTS) {
+            throw new TooManyRequestsHttpException('Too many password reset requests. Please try again later.');
+        }
+    }
+}


### PR DESCRIPTION
#### Description

This PR implements `ThrottlePasswordResetRequestService` which enforces a restriction on password reset request frequency per user. If the number of requests exceeds a configured limit within a defined time window, a `TooManyRequestsHttpException` is thrown.

The service is tested under the following scenarios:
-  Within limit (e.g. 3 requests): should pass without exception
- Over limit (e.g. 6 requests): should raise `TooManyRequestsHttpException`
- Wrong user (requests belong to a different user): should not trigger throttling