### PR TITLE
Implement Integration Test for Password Reset Request API

### DIFF
--- a/src/app/Providers/AppServiceProvider.php
+++ b/src/app/Providers/AppServiceProvider.php
@@ -7,8 +7,15 @@ use App\Post\Domain\RepositoryInterface\PostRepositoryInterface;
 use App\Post\Infrastructure\Repository\PostRepository;
 use App\User\Domain\RepositoryInterface\PasswordHasherInterface;
 use App\User\Domain\RepositoryInterface\UserRepositoryInterface;
+use App\User\Domain\Service\PasswordResetGenerateTokenServiceInterface;
+use App\User\Domain\Service\PasswordResetNotificationServiceInterface;
+use App\User\Domain\Service\PasswordResetRequestLimitationServiceInterface;
+use App\User\Domain\Service\ThrottlePasswordResetRequestServiceInterface;
 use App\User\Infrastructure\Repository\UserRepository;
 use App\User\Infrastructure\Service\JwtAuthService;
+use App\User\Infrastructure\Service\PasswordResetGenerateTokenService;
+use App\User\Infrastructure\Service\PasswordResetNotificationService;
+use App\User\Infrastructure\Service\ThrottlePasswordResetRequestService;
 use Illuminate\Support\ServiceProvider;
 use App\User\Infrastructure\Service\BcryptPasswordHasher;
 use App\User\Domain\Service\GenerateTokenInterface;
@@ -56,6 +63,21 @@ class AppServiceProvider extends ServiceProvider
         $this->app->bind(
             GetPostQueryServiceInterface::class,
             GetPostQueryService::class
+        );
+
+        $this->app->bind(
+            PasswordResetGenerateTokenServiceInterface::class,
+            PasswordResetGenerateTokenService::class
+        );
+
+        $this->app->bind(
+            PasswordResetNotificationServiceInterface::class,
+            PasswordResetNotificationService::class
+        );
+
+        $this->app->bind(
+            ThrottlePasswordResetRequestServiceInterface::class,
+            ThrottlePasswordResetRequestService::class
         );
     }
 

--- a/src/app/User/Tests/User_PasswordResetRequestTest.php
+++ b/src/app/User/Tests/User_PasswordResetRequestTest.php
@@ -1,0 +1,75 @@
+<?php
+
+namespace App\User\Tests;
+
+use App\Models\PasswordResetRequest;
+use Tests\TestCase;
+use Illuminate\Support\Facades\DB;
+use App\Models\User;
+
+class User_PasswordResetRequestTest extends TestCase
+{
+    private $endpoint = '/api/users/password-reset';
+    private $user;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->refreshDatabase();
+        $this->user = $this->createUser();
+    }
+
+    protected function tearDown(): void
+    {
+        $this->refreshDatabase();
+        parent::tearDown();
+    }
+
+    private function refreshDatabase(): void
+    {
+        if (env('APP_ENV') === 'testing') {
+            DB::connection('mysql')->statement('SET FOREIGN_KEY_CHECKS=0;');
+            User::truncate();
+            PasswordResetRequest::truncate();
+            DB::connection('mysql')->statement('SET FOREIGN_KEY_CHECKS=1;');
+        }
+    }
+
+    private function createUser(): User
+    {
+        $user = User::create([
+            'first_name' => 'Lionel',
+            'last_name' => 'Messi',
+            'email' => "barcelona_".rand(). "@test.com",
+            'password' => 'test1234',
+            'bio' => 'I am a football player',
+            'location' => 'Barcelona',
+            'skills' => ['Laravel', 'React'],
+            'profile_image' => 'https://example.com/profile.jpg',
+        ]);
+
+        return $user;
+    }
+
+    public function test_password_reset_request_ok(): void
+    {
+        $input = $this->user->email;
+
+        $response = $this
+            ->postJson(
+                $this->endpoint,
+                [
+                    'email' => $input,
+                ]
+            );
+
+        $response->assertStatus(200);
+        $this->assertDatabaseHas(
+            'password_reset_requests',
+            [
+                'user_id' => $this->user->id,
+            ],
+            'mysql'
+        );
+    }
+}

--- a/src/routes/api.php
+++ b/src/routes/api.php
@@ -12,6 +12,7 @@ Route::prefix('users')->name('user.')->group(function () {
     Route::post('login', [UserController::class, 'login'])->name('login');
     Route::get('/show/{id}', [UserController::class, 'showUser'])->name('show');
     Route::put('{id}', [UserController::class, 'update'])->name('update');
+    Route::post('/password-reset', [UserController::class, 'passwordResetRequest'])->name('passwordResetRequest');
 
     Route::prefix('{userId}/posts')->name('posts.')->group(function () {
         Route::post('/', [PostController::class, 'create'])->name('create');


### PR DESCRIPTION
### Description

This PR adds an integration test for the password reset request feature to ensure that:

- A registered user can successfully request a password reset using a valid email.
- A password reset token is stored in the `password_reset_requests` table.
- The endpoint responds with HTTP 200 on success.

---

### Changes

- Created `User_PasswordResetRequestTest` in `App\User\Tests`.
- Ensured database reset before and after each test (`User` and `PasswordResetRequest`).
- Tested the POST `/api/users/password-reset` endpoint.
- Verified `password_reset_requests` DB entry after successful request.