### PR TITLE
Implement password reset token validation logic and Interface

### DIFF
--- a/src/app/User/Domain/Service/PasswordResetTokenValidatorInterface.php
+++ b/src/app/User/Domain/Service/PasswordResetTokenValidatorInterface.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace App\User\Domain\Service;
+
+interface PasswordResetTokenValidatorInterface
+{
+    public function validate(
+        string $userId,
+        string $token,
+    ): void;
+}

--- a/src/app/User/Infrastructure/InfrastructureTest/Service/PasswordResetTokenValidatorServiceTest.php
+++ b/src/app/User/Infrastructure/InfrastructureTest/Service/PasswordResetTokenValidatorServiceTest.php
@@ -1,0 +1,75 @@
+<?php
+
+namespace App\User\Infrastructure\InfrastructureTest\Service;
+
+use App\Models\PasswordResetRequest;
+use App\Models\User;
+use App\User\Infrastructure\Service\PasswordResetTokenValidatorService;
+use Illuminate\Support\Facades\DB;
+use Tests\TestCase;
+
+class PasswordResetTokenValidatorServiceTest extends TestCase
+{
+    private $service;
+    private $user;
+    private $resetRequest;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->refresh();
+        $this->service = new PasswordResetTokenValidatorService();
+        $this->user = $this->createUser();
+        $this->resetRequest = $this->createResetRequest();
+    }
+
+    protected function tearDown(): void
+    {
+        $this->refresh();
+        parent::tearDown();
+    }
+
+    private function refresh(): void
+    {
+        if (env('APP_ENV') === 'testing') {
+            DB::connection('mysql')->statement('SET FOREIGN_KEY_CHECKS=0;');
+            User::truncate();
+            PasswordResetRequest::truncate();
+            DB::connection('mysql')->statement('SET FOREIGN_KEY_CHECKS=1;');
+        }
+    }
+
+    private function createUser(): User
+    {
+        return User::Create([
+            'first_name' => 'Sergio',
+            'last_name' => 'Ramos',
+            'email' => "real-madrid".rand(). "@test.com",
+            'password' => 'el-capitán-1234',
+            'bio' => 'Real Madrid player',
+            'location' => 'Madrid',
+            'skills' => ['Football', 'Leadership'],
+            'profile_image' => 'https://example.com/sergio.jpg'
+        ]);
+    }
+
+    private function createResetRequest(): PasswordResetRequest
+    {
+        return PasswordResetRequest::create([
+            'user_id' => $this->user->id,
+            'token' => bin2hex(random_bytes(32)),
+            'requested_at' => now(),
+            'expired_at' => now()->addMinutes(30),
+        ]);
+    }
+
+    public function test_check_token_validate(): void
+    {
+        $this->expectNotToPerformAssertions();
+
+        $this->service->validate(
+            $this->user->id,
+            $this->resetRequest->token
+        );
+    }
+}

--- a/src/app/User/Infrastructure/Service/PasswordResetTokenValidatorService.php
+++ b/src/app/User/Infrastructure/Service/PasswordResetTokenValidatorService.php
@@ -24,7 +24,7 @@ class PasswordResetTokenValidatorService implements PasswordResetTokenValidatorI
         return DB::table('password_reset_requests')
             ->where('token', $token)
             ->where('user_id', $userId)
-            ->where('created_at', '>=', now()->subMinutes(60))
+            ->where('requested_at', '>=', now()->subMinutes(60))
             ->exists();
     }
 }

--- a/src/app/User/Infrastructure/Service/PasswordResetTokenValidatorService.php
+++ b/src/app/User/Infrastructure/Service/PasswordResetTokenValidatorService.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace App\User\Infrastructure\Service;
+
+use App\User\Domain\Service\PasswordResetTokenValidatorInterface;
+use Illuminate\Support\Facades\DB;
+use InvalidArgumentException;
+
+class PasswordResetTokenValidatorService implements PasswordResetTokenValidatorInterface
+{
+    public function validate(string $userId, string $token): void
+    {
+        if (empty($userId) || empty($token)) {
+            throw new InvalidArgumentException('User ID and token must not be empty.');
+        }
+
+        if (!$this->isValidToken($userId, $token)) {
+            throw new InvalidArgumentException('Invalid password reset token.');
+        }
+    }
+
+    private function isValidToken($userId, $token): bool
+    {
+        return DB::table('password_reset_requests')
+            ->where('token', $token)
+            ->where('user_id', $userId)
+            ->where('created_at', '>=', now()->subMinutes(60))
+            ->exists();
+    }
+}


### PR DESCRIPTION
### Description

This pull request introduces the implementation of the `PasswordResetTokenValidatorService`, responsible for validating a password reset token by verifying:

- That both the `user_id` and `token` are present and non-empty
- That a matching record exists in the `password_reset_requests` table
- That the token was issued within the last 60 minutes (`requested_at` threshold)

The logic conforms to domain expectations by:

- Throwing `InvalidArgumentException` for missing or invalid input
- Encapsulating the DB validation logic within a private helper method `isValidToken`

The implementation adheres to the `PasswordResetTokenValidatorInterface` and is placed under the Infrastructure layer to isolate external dependencies (e.g., DB access).
