### PR TITLE
Implement PasswordResetUseCase with Token Validation and Repository Delegation

### DIFF
--- a/src/app/User/Application/ApplicationTest/PasswordResetUseCaseTest.php
+++ b/src/app/User/Application/ApplicationTest/PasswordResetUseCaseTest.php
@@ -1,0 +1,78 @@
+<?php
+
+namespace App\User\Application\ApplicationTest;
+
+use Tests\TestCase;
+use App\User\Application\UseCase\PasswordResetUseCase;
+use App\User\Domain\RepositoryInterface\UserRepositoryInterface;
+use App\Common\Domain\ValueObject\UserId;
+use App\User\Domain\ValueObject\PasswordResetToken;
+use App\User\Domain\Service\PasswordResetTokenValidatorInterface;
+use Mockery;
+
+class PasswordResetUseCaseTest extends TestCase
+{
+    private $userId;
+    private string $token;
+
+    private string $newPassword;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->userId = 1;
+        $this->token = bin2hex(random_bytes(32));
+    }
+
+    protected function tearDown(): void
+    {
+        parent::tearDown();
+    }
+
+    private function mockRepository(): UserRepositoryInterface
+    {
+        $repository = Mockery::mock(UserRepositoryInterface::class);
+
+        $repository
+            ->shouldReceive('resetPassword')
+            ->with(
+                Mockery::type(UserId::class),
+                Mockery::type(PasswordResetToken::class),
+                Mockery::type('string')
+            )
+            ->andReturn(true);
+
+        return $repository;
+    }
+
+    private function mockTokenValidator(): PasswordResetTokenValidatorInterface
+    {
+        $tokenValidator = Mockery::mock(PasswordResetTokenValidatorInterface::class);
+
+        $tokenValidator
+            ->shouldReceive('validate')
+            ->with(
+                Mockery::type('string'),
+                Mockery::type('string')
+            )
+            ->andReturn(true);
+
+        return $tokenValidator;
+    }
+
+    public function test_use_case_ok(): void
+    {
+        $useCase = new PasswordResetUseCase(
+            $this->mockRepository(),
+            $this->mockTokenValidator()
+        );
+
+        $useCase->handle(
+            $this->userId,
+            $this->token,
+            'new-password-1234'
+        );
+
+        $this->assertTrue(true, 'Password reset use case executed successfully');
+    }
+}

--- a/src/app/User/Application/UseCase/PasswordResetUseCase.php
+++ b/src/app/User/Application/UseCase/PasswordResetUseCase.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace App\User\Application\UseCase;
+
+use App\User\Domain\RepositoryInterface\UserRepositoryInterface;
+use App\User\Domain\Service\PasswordResetTokenValidatorInterface;
+use App\User\Domain\ValueObject\PasswordResetToken;
+use App\Common\Domain\ValueObject\UserId;
+
+class PasswordResetUseCase
+{
+    public function __construct(
+        private readonly UserRepositoryInterface $repository,
+        private readonly PasswordResetTokenValidatorInterface $tokenValidator,
+    ) {}
+
+    public function handle(
+        string $userId,
+        string $token,
+        string $newPassword
+    ): void
+    {
+        $objectUserId = $this->buildObjectUserId($userId);
+        $objectToken = $this->buildObjectToken($token);
+
+
+        $this->tokenValidator
+            ->validate(
+                $objectUserId->getValue(),
+                $objectToken->getValue()
+            );
+
+        $this->repository
+            ->resetPassword(
+                $objectUserId,
+                $objectToken,
+                $newPassword
+            );
+    }
+
+    private function buildObjectUserId(string $userId): UserId
+    {
+        return new UserId($userId);
+    }
+
+    private function buildObjectToken(string $token): PasswordResetToken
+    {
+        return new PasswordResetToken($token);
+    }
+}


### PR DESCRIPTION
###  Description
This PR introduces the `PasswordResetUseCase` class in the Application layer, which encapsulates the password reset logic by coordinating the following:

- Converts raw `userId` and `token` strings into respective value objects: `UserId` and `PasswordResetToken`
- Validates the token against a domain service `PasswordResetTokenValidatorInterface`
- Delegates the password reset operation to the `UserRepositoryInterface`
