### PR TITLE
Implement query service for retrieving user and other users' posts with pagination support

### DIFF
--- a/src/app/Common/Domain/Enum/PostVisibility.php
+++ b/src/app/Common/Domain/Enum/PostVisibility.php
@@ -2,29 +2,10 @@
 
 namespace App\Common\Domain\Enum;
 
-use InvalidArgumentException;
-
-enum PostVisibility: string
+enum PostVisibility: int
 {
-    case PUBLIC = 'public';
-    case PRIVATE = 'private';
-
-    public static function fromString(string $value): self
-    {
-        return match ($value) {
-            self::PUBLIC->value => self::PUBLIC,
-            self::PRIVATE->value => self::PRIVATE,
-            default => throw new InvalidArgumentException("Invalid PostVisibility: {$value}"),
-        };
-    }
-
-    public function toInt(): int
-    {
-        return match ($this) {
-            self::PUBLIC => 1,
-            self::PRIVATE => 2,
-        };
-    }
+    case PUBLIC = 0;
+    case PRIVATE = 1;
 
     public function toLabel(): string
     {

--- a/src/app/Models/Post.php
+++ b/src/app/Models/Post.php
@@ -23,11 +23,12 @@ class Post extends Model
         return $this->belongsTo(User::class, 'user_id');
     }
 
-    protected function visibility(): Attribute
+    protected $casts = [
+        'visibility' => PostVisibility::class,
+    ];
+
+    public function getVisibilityLabelAttribute(): string
     {
-        return Attribute::make(
-            get: fn ($value) => $value === 0 ? 'public' : 'private',
-            set: fn ($value) => $value === 'public' ? 0 : 1,
-        );
+        return $this->visibility->toLabel();
     }
 }

--- a/src/app/Post/Application/QueryServiceInterface/GetPostQueryServiceInterface.php
+++ b/src/app/Post/Application/QueryServiceInterface/GetPostQueryServiceInterface.php
@@ -19,4 +19,17 @@ interface GetPostQueryServiceInterface
         UserId $userId,
         PostId $postId
     ): ?PostEntity;
+
+    public function getOthersAllPosts(
+        int $userId,
+        int $perPage,
+        int $currentPage
+    ): ?PaginationDto;
+
+//    public function getOneAllPosts(
+//        int $userId,
+//        int $targetUserId,
+//        int $perPage,
+//        int $currentPage
+//    ): PaginationDto;
 }

--- a/src/app/Post/Domain/EntityFactory/PostFromModelEntityFactory.php
+++ b/src/app/Post/Domain/EntityFactory/PostFromModelEntityFactory.php
@@ -18,7 +18,7 @@ class PostFromModelEntityFactory
             'content' => $request['content'],
             'mediaPath' => $request['media_path'] ?? null,
             'visibility' => new PostVisibility(
-                PostVisibilityEnum::fromString($request['visibility'])
+                PostVisibilityEnum::from($request['visibility'] ?? PostVisibilityEnum::PUBLIC)
             ),
         ]);
     }

--- a/src/app/Post/Infrastructure/InfrastructureTest/GetOthersAllPostsQueryServiceTest.php
+++ b/src/app/Post/Infrastructure/InfrastructureTest/GetOthersAllPostsQueryServiceTest.php
@@ -1,0 +1,120 @@
+<?php
+
+namespace App\Post\Infrastructure\InfrastructureTest;
+
+use App\Post\Domain\Entity\PostEntity;
+use App\Post\Infrastructure\QueryService\GetPostQueryService;
+use Tests\TestCase;
+use App\Post\Application\QueryServiceInterface\GetPostQueryServiceInterface;
+use App\Common\Application\DtoFactory\PaginationFactory;
+use App\Common\Application\Dto\Pagination as PaginationDto;
+use Mockery;
+use Illuminate\Support\Facades\DB;
+use App\Models\User;
+use App\Models\Post;
+
+class GetOthersAllPostsQueryServiceTest extends TestCase
+{
+
+    private $user;
+    private int $currentPage = 1;
+    private int $perPage = 10;
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->refresh();
+        $this->user = $this->createUsersWithPosts();
+    }
+
+    protected function tearDown(): void
+    {
+        $this->refresh();
+        parent::tearDown();
+    }
+
+    private function refresh(): void
+    {
+        if (env('APP_ENV') === 'testing') {
+            DB::connection('mysql')->statement('SET FOREIGN_KEY_CHECKS=0;');
+            User::truncate();
+            Post::truncate();
+            DB::connection('mysql')->statement('SET FOREIGN_KEY_CHECKS=1;');
+        }
+    }
+
+    private function createUsersWithPosts(): User
+    {
+        $users = [];
+
+        for ($i = 1; $i <= 3; $i++) {
+            $user = User::create([
+                'first_name' => "User{$i}",
+                'last_name' => "Test{$i}",
+                'email' => "user{$i}@example.com",
+                'password' => bcrypt('password123'),
+                'bio' => "This is user {$i}",
+                'location' => "City{$i}",
+                'skills' => ['Laravel', 'Vue'],
+                'profile_image' => 'https://example.com/user.jpg',
+            ]);
+
+            $visibility = $i % 2 === 0 ? 0 : 1;
+            for ($j = 1; $j <= 20; $j++) {
+                Post::create([
+                    'user_id' => $user->id,
+                    'content' => "Post {$j} by User{$i}",
+                    'media_path' => null,
+                    'visibility' => $visibility,
+                    'created_at' => now()->subMinutes(rand(0, 1000)),
+                    'updated_at' => now(),
+                ]);
+            }
+
+            $users[] = $user;
+        }
+
+        return $users[0];
+    }
+
+    public function test_check_query_service_return_type(): void
+    {
+        $queryService = new GetPostQueryService(
+            new Post(),
+            new User(),
+        );
+
+        $result = $queryService->getOthersAllPosts(
+            $this->user->id,
+            $this->currentPage,
+            $this->perPage
+        );
+
+        $this->assertInstanceOf(
+            PaginationDto::class,
+            $result
+        );
+    }
+
+    public function test_check_query_service_return_value(): void
+    {
+        $queryService = new GetPostQueryService(
+            new Post(),
+            new User(),
+        );
+
+        $result = $queryService->getOthersAllPosts(
+            $this->user->id,
+            $this->currentPage,
+            $this->perPage
+        );
+
+        $this->assertEquals($this->currentPage, $result->getCurrentPage());
+        $this->assertEquals($this->perPage, $result->getPerPage());
+        foreach ($result->getData() as $post) {
+            $this->assertInstanceOf(
+                PostEntity::class,
+                $post
+            );
+        }
+    }
+}

--- a/src/app/Post/Infrastructure/QueryService/GetPostQueryService.php
+++ b/src/app/Post/Infrastructure/QueryService/GetPostQueryService.php
@@ -11,6 +11,7 @@ use App\Post\Domain\EntityFactory\PostFromModelEntityFactory;
 use App\Common\Application\Dto\Pagination as PaginationDto;
 use App\Models\User;
 use ErrorException;
+use App\Common\Domain\Enum\PostVisibility as PostVisibilityEnum;
 
 class GetPostQueryService implements GetPostQueryServiceInterface
 {
@@ -83,5 +84,28 @@ class GetPostQueryService implements GetPostQueryServiceInterface
             prevPageUrl: $data['prev_page_url'] ?? null,
             links: $data['links'] ?? null
         );
+    }
+
+    public function getOthersAllPosts(
+        int $userId,
+        int $perPage,
+        int $currentPage
+    ): ?PaginationDto {
+
+        $allPosts = $this->post
+            ->where('user_id', '!=', $userId)
+            ->where('visibility', PostVisibilityEnum::PUBLIC->value)
+            ->paginate(
+                $currentPage,
+                ['*'],
+                'page',
+                $perPage
+            );
+
+        if (empty($allPosts)) {
+            return null;
+        }
+
+        return $this->paginationDto($allPosts->toArray());
     }
 }


### PR DESCRIPTION
### Description

- `getAllUserPosts`: Retrieve all posts created by a specific user, with pagination.
- `getEachUserPost`: Retrieve a single post by a given user.
- `getOthersAllPosts`: Retrieve all public posts made by users other than the current user, with pagination.

Each method transforms database records into domain entities (`PostEntity`) via `PostFromModelEntityFactory`, and wraps paginated results in a standardised `PaginationDto`.
