### PR TITLE
Add GetOthersPostsController action and its feature test

### DIFF
--- a/src/app/Post/Presentation/PresentationTest/Controller/PostController_getOthersPostsTest.php
+++ b/src/app/Post/Presentation/PresentationTest/Controller/PostController_getOthersPostsTest.php
@@ -1,0 +1,90 @@
+<?php
+
+namespace App\Post\Presentation\PresentationTest\Controller;
+
+use App\Common\Application\ApplicationTest\PaginationDtoTest;
+use App\Post\Application\UseCase\GetOthersAllPostsUseCase;
+use App\Post\Presentation\Controller\PostController;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+use Tests\TestCase;
+use Mockery;
+use App\Common\Presentation\ViewModel\Pagination;
+use App\Post\Presentation\ViewModel\GetPostsViewModelCollection;
+use App\Common\Application\Dto\Pagination as PaginationDto;
+
+class PostController_getOthersPostsTest extends TestCase
+{
+
+    private $currentPage;
+    private $perPage;
+
+    private $controller;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->currentPage = 1;
+        $this->perPage = 10;
+        $this->controller = new PostController();
+    }
+
+    protected function tearDown(): void
+    {
+        parent::tearDown();
+    }
+
+    private function mockUseCase(): GetOthersAllPostsUseCase
+    {
+        $useCase = Mockery::mock(GetOthersAllPostsUseCase::class);
+
+        $useCase->shouldReceive('handle')
+            ->with(
+                Mockery::type('int'),
+                Mockery::type($this->perPage),
+                Mockery::type($this->currentPage)
+            )
+            ->andReturn($this->mockPagination());
+
+        return $useCase;
+    }
+
+    private function mockPagination(): PaginationDto
+    {
+        $paginationDto = Mockery::mock(PaginationDto::class);
+
+        $paginationDto->shouldReceive('getCurrentPage')
+            ->andReturn($this->currentPage);
+
+        $paginationDto->shouldReceive('getPerPage')
+            ->andReturn($this->perPage);
+
+        return $paginationDto;
+    }
+
+    private function mockRequest(): Request
+    {
+        $request = Mockery::mock(Request::class);
+
+        $request->shouldReceive('input')
+            ->with('perPage')
+            ->andReturn($this->perPage);
+
+        $request->shouldReceive('input')
+            ->with('currentPage')
+            ->andReturn($this->currentPage);
+
+        return $request;
+    }
+
+    public function test_controller_type_check(): void
+    {
+        $result = $this->controller->getOthersPosts(
+            $this->mockRequest(),
+            1,
+            $this->mockUseCase()
+        );
+
+        $this->assertInstanceOf(JsonResponse::class, $result);
+    }
+}

--- a/src/app/Post/Presentation/PresentationTest/Controller/PostController_getOthersPostsTest.php
+++ b/src/app/Post/Presentation/PresentationTest/Controller/PostController_getOthersPostsTest.php
@@ -2,15 +2,12 @@
 
 namespace App\Post\Presentation\PresentationTest\Controller;
 
-use App\Common\Application\ApplicationTest\PaginationDtoTest;
 use App\Post\Application\UseCase\GetOthersAllPostsUseCase;
 use App\Post\Presentation\Controller\PostController;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
 use Tests\TestCase;
 use Mockery;
-use App\Common\Presentation\ViewModel\Pagination;
-use App\Post\Presentation\ViewModel\GetPostsViewModelCollection;
 use App\Common\Application\Dto\Pagination as PaginationDto;
 
 class PostController_getOthersPostsTest extends TestCase

--- a/src/app/Post/Presentation/PresentationTest/GetPostViewModelCollectionTest.php
+++ b/src/app/Post/Presentation/PresentationTest/GetPostViewModelCollectionTest.php
@@ -84,31 +84,6 @@ class GetPostViewModelCollectionTest extends TestCase
         ];
     }
 
-    private function mockEntityCollection(): PostEntityCollection
-    {
-        $collection = Mockery::mock(PostEntityCollection::class);
-
-        $collection->shouldReceive('getPosts')
-            ->andReturn([
-                new GetPostViewModel(
-                    1,
-                    1,
-                    'Sample content',
-                    'https://example.com/media.jpg',
-                    'public'
-                ),
-                new GetPostViewModel(
-                    2,
-                    1,
-                    'Another content',
-                    'https://example.com/another_media.jpg',
-                    'private'
-                )
-            ]);
-
-        return $collection;
-    }
-
     public function test_view_model_collection_check_type(): void
     {
         $collection = new GetPostsViewModelCollection(


### PR DESCRIPTION
### Description

This PR introduces the `getOthersPosts()` controller action which handles the retrieval of paginated public posts by users other than the specified user ID. It integrates:

- Request validation and pagination parameters (`per_page`, `current_page`)
- UseCase invocation: `GetOthersAllPostsUseCase`
- DTO to ViewModel mapping (`GetUserEachPostDto` → `GetAllUserPostViewModel`)
- PaginationViewModel formatting using `PaginationViewModelFactory`
- JSON response formatting with `status`, `data`, and `meta`
- Global `Throwable` exception catch and error response