### PR TITLE
Merge Presentation layer for GetOthersPosts flow (Controller, ViewModel, Factory)

### DIFF
--- a/src/app/Post/Application/Dto/GetAllUserPostDtoCollection.php
+++ b/src/app/Post/Application/Dto/GetAllUserPostDtoCollection.php
@@ -7,10 +7,10 @@ use App\Post\Application\Dto\GetUserEachPostDto as PostDto;
 class GetAllUserPostDtoCollection
 {
     /**
-     * @param PostDto[] $items
+     * @param PostDto[] $posts
      */
     public function __construct(
-        public readonly array $items
+        public readonly array $posts
     ) {}
 
     public static function build(array $items): self
@@ -30,6 +30,6 @@ class GetAllUserPostDtoCollection
      */
     public function getPosts(): array
     {
-        return $this->items;
+        return $this->posts;
     }
 }

--- a/src/app/Post/Application/UseCase/GetOthersAllPostsUseCase.php
+++ b/src/app/Post/Application/UseCase/GetOthersAllPostsUseCase.php
@@ -3,6 +3,8 @@
 namespace App\Post\Application\UseCase;
 
 use App\Common\Application\Dto\Pagination as PaginationDto;
+use App\Post\Application\Dto\GetAllUserPostDtoCollection;
+use App\Post\Application\Dto\GetUserEachPostDto;
 use App\Post\Application\QueryServiceInterface\GetPostQueryServiceInterface;
 
 class GetOthersAllPostsUseCase
@@ -17,10 +19,25 @@ class GetOthersAllPostsUseCase
         int $currentPage
     ): PaginationDto {
 
-        return $this->queryService->getOthersAllPosts(
+        $allPosts = $this->queryService->getOthersAllPosts(
             userId: $userId,
             perPage: $perPage,
             currentPage: $currentPage
+        );
+
+        $postDtos = new GetAllUserPostDtoCollection(
+            array_map(
+                fn($post) => GetUserEachPostDto::build($post->toArray()),
+                $allPosts->getData()
+            )
+        );
+
+        return new PaginationDto(
+            data: $postDtos->getPosts(),
+            total: $allPosts->getTotal(),
+            perPage: $allPosts->getPerPage(),
+            currentPage: $allPosts->getCurrentPage(),
+            lastPage: $allPosts->getLastPage()
         );
     }
 }

--- a/src/app/Post/Infrastructure/QueryService/GetPostQueryService.php
+++ b/src/app/Post/Infrastructure/QueryService/GetPostQueryService.php
@@ -94,7 +94,7 @@ class GetPostQueryService implements GetPostQueryServiceInterface
         int $currentPage
     ): ?PaginationDto {
 
-        $allPosts = $this->post
+        $getPosts = $this->post
             ->where('user_id', '!=', $userId)
             ->where('visibility', PostVisibilityEnum::PUBLIC->value)
             ->paginate(
@@ -104,9 +104,13 @@ class GetPostQueryService implements GetPostQueryServiceInterface
                 $currentPage
             );
 
-        if (empty($allPosts)) {
+        if (empty($getPosts)) {
             return null;
         }
+
+        $allPosts = $getPosts->map(function ($post) {
+            return PostFromModelEntityFactory::build($post->toArray());
+        });
 
         return $this->paginationDto($allPosts->toArray());
     }

--- a/src/app/Post/Presentation/PresentationTest/Controller/PostController_getOthersPostsTest.php
+++ b/src/app/Post/Presentation/PresentationTest/Controller/PostController_getOthersPostsTest.php
@@ -1,0 +1,87 @@
+<?php
+
+namespace App\Post\Presentation\PresentationTest\Controller;
+
+use App\Post\Application\UseCase\GetOthersAllPostsUseCase;
+use App\Post\Presentation\Controller\PostController;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+use Tests\TestCase;
+use Mockery;
+use App\Common\Application\Dto\Pagination as PaginationDto;
+
+class PostController_getOthersPostsTest extends TestCase
+{
+
+    private $currentPage;
+    private $perPage;
+
+    private $controller;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->currentPage = 1;
+        $this->perPage = 10;
+        $this->controller = new PostController();
+    }
+
+    protected function tearDown(): void
+    {
+        parent::tearDown();
+    }
+
+    private function mockUseCase(): GetOthersAllPostsUseCase
+    {
+        $useCase = Mockery::mock(GetOthersAllPostsUseCase::class);
+
+        $useCase->shouldReceive('handle')
+            ->with(
+                Mockery::type('int'),
+                Mockery::type($this->perPage),
+                Mockery::type($this->currentPage)
+            )
+            ->andReturn($this->mockPagination());
+
+        return $useCase;
+    }
+
+    private function mockPagination(): PaginationDto
+    {
+        $paginationDto = Mockery::mock(PaginationDto::class);
+
+        $paginationDto->shouldReceive('getCurrentPage')
+            ->andReturn($this->currentPage);
+
+        $paginationDto->shouldReceive('getPerPage')
+            ->andReturn($this->perPage);
+
+        return $paginationDto;
+    }
+
+    private function mockRequest(): Request
+    {
+        $request = Mockery::mock(Request::class);
+
+        $request->shouldReceive('input')
+            ->with('perPage')
+            ->andReturn($this->perPage);
+
+        $request->shouldReceive('input')
+            ->with('currentPage')
+            ->andReturn($this->currentPage);
+
+        return $request;
+    }
+
+    public function test_controller_type_check(): void
+    {
+        $result = $this->controller->getOthersPosts(
+            $this->mockRequest(),
+            1,
+            $this->mockUseCase()
+        );
+
+        $this->assertInstanceOf(JsonResponse::class, $result);
+    }
+}

--- a/src/app/Post/Presentation/PresentationTest/GetPostViewModelCollectionTest.php
+++ b/src/app/Post/Presentation/PresentationTest/GetPostViewModelCollectionTest.php
@@ -1,0 +1,135 @@
+<?php
+
+namespace App\Post\Presentation\PresentationTest;
+
+use App\Post\Domain\Entity\PostEntityCollection;
+use Tests\TestCase;
+use App\Post\Presentation\ViewModel\GetPostViewModel;
+use App\Post\Application\Dto\GetAllUserPostDtoCollection;
+use Mockery;
+use App\Post\Presentation\ViewModel\GetPostsViewModelCollection;
+use App\Common\Application\Dto\Pagination as PaginationDto;
+use App\Post\Application\Dto\GetUserEachPostDto;
+
+class GetPostViewModelCollectionTest extends TestCase
+{
+    private $currentPage;
+    private $perPage;
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->currentPage = 1;
+        $this->perPage = 10;
+    }
+
+    protected function tearDown(): void
+    {
+        parent::tearDown();
+    }
+
+    private function mockPagination(): PaginationDto
+    {
+        $pagination = Mockery::mock(PaginationDto::class);
+
+        $pagination->shouldReceive('getCurrentPage')
+            ->andReturn($this->currentPage);
+
+        $pagination->shouldReceive('getPerPage')
+            ->andReturn($this->perPage);
+
+        return $pagination;
+    }
+
+    private function mockDtoCollection(): GetAllUserPostDtoCollection
+    {
+        $dto1 = new GetUserEachPostDto(
+            id: 1,
+            userId: 1,
+            content: 'Sample content',
+            mediaPath: 'https://example.com/media.jpg',
+            visibility: 'public'
+        );
+
+        $dto2 = new GetUserEachPostDto(
+            id: 2,
+            userId: 1,
+            content: 'Another content',
+            mediaPath: 'https://example.com/another_media.jpg',
+            visibility: 'private'
+        );
+
+        $collection = Mockery::mock(GetAllUserPostDtoCollection::class);
+        $collection->shouldReceive('getPosts')->andReturn([$dto1, $dto2]);
+
+        return $collection;
+    }
+
+    private function arrayData(): array
+    {
+        return [
+            [
+                'id' => 1,
+                'userId' => 1,
+                'content' => 'Sample content',
+                'mediaPath' => 'https://example.com/media.jpg',
+                'visibility' => 'public'
+            ],
+            [
+                'id' => 2,
+                'userId' => 1,
+                'content' => 'Another content',
+                'mediaPath' => 'https://example.com/another_media.jpg',
+                'visibility' => 'private'
+            ]
+        ];
+    }
+
+    private function mockEntityCollection(): PostEntityCollection
+    {
+        $collection = Mockery::mock(PostEntityCollection::class);
+
+        $collection->shouldReceive('getPosts')
+            ->andReturn([
+                new GetPostViewModel(
+                    1,
+                    1,
+                    'Sample content',
+                    'https://example.com/media.jpg',
+                    'public'
+                ),
+                new GetPostViewModel(
+                    2,
+                    1,
+                    'Another content',
+                    'https://example.com/another_media.jpg',
+                    'private'
+                )
+            ]);
+
+        return $collection;
+    }
+
+    public function test_view_model_collection_check_type(): void
+    {
+        $collection = new GetPostsViewModelCollection(
+            $this->mockDtoCollection()
+        );
+
+        $this->assertInstanceOf(
+            GetPostsViewModelCollection::class,
+            $collection
+        );
+    }
+
+    public function test_view_model_collection_check_value(): void
+    {
+        $collection = new GetPostsViewModelCollection(
+            $this->mockDtoCollection()
+        );
+
+        $this->assertEquals(
+            $this->arrayData(),
+            $collection->toArray()
+        );
+    }
+}

--- a/src/app/Post/Presentation/PresentationTest/GetPostViewModelCollectionTest.php
+++ b/src/app/Post/Presentation/PresentationTest/GetPostViewModelCollectionTest.php
@@ -84,31 +84,6 @@ class GetPostViewModelCollectionTest extends TestCase
         ];
     }
 
-    private function mockEntityCollection(): PostEntityCollection
-    {
-        $collection = Mockery::mock(PostEntityCollection::class);
-
-        $collection->shouldReceive('getPosts')
-            ->andReturn([
-                new GetPostViewModel(
-                    1,
-                    1,
-                    'Sample content',
-                    'https://example.com/media.jpg',
-                    'public'
-                ),
-                new GetPostViewModel(
-                    2,
-                    1,
-                    'Another content',
-                    'https://example.com/another_media.jpg',
-                    'private'
-                )
-            ]);
-
-        return $collection;
-    }
-
     public function test_view_model_collection_check_type(): void
     {
         $collection = new GetPostsViewModelCollection(

--- a/src/app/Post/Presentation/PresentationTest/GetPostViewModelTest.php
+++ b/src/app/Post/Presentation/PresentationTest/GetPostViewModelTest.php
@@ -1,0 +1,109 @@
+<?php
+
+namespace App\Post\Presentation\PresentationTest;
+
+use App\Post\Application\Dto\GetUserEachPostDto;
+use Tests\TestCase;
+use App\Post\Presentation\ViewModel\GetPostViewModel;
+use App\Common\Application\Dto\Pagination as PaginationDto;
+use Mockery;
+
+class GetPostViewModelTest extends TestCase
+{
+    private $currentPage;
+    private $perPage;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->currentPage = 1;
+        $this->perPage = 10;
+    }
+
+    protected function tearDown(): void
+    {
+        parent::tearDown();
+    }
+
+    private function mockPagination(): PaginationDto
+    {
+        $dto = Mockery::mock(PaginationDto::class);
+
+        $dto->shouldReceive('getCurrentPage')
+            ->andReturn($this->currentPage);
+
+        $dto->shouldReceive('getPerPage')
+            ->andReturn($this->perPage);
+
+        $dto->shouldReceive('getData')
+            ->andReturn($this->arrayData());
+
+        return $dto;
+    }
+
+    private function mockDto(): GetUserEachPostDto
+    {
+        $dto = Mockery::mock(GetUserEachPostDto::class);
+
+        $dto->shouldReceive('getId')
+            ->andReturn(1);
+
+        $dto->shouldReceive('getUserId')
+            ->andReturn(1);
+
+        $dto->shouldReceive('getContent')
+            ->andReturn('Sample content');
+
+        $dto->shouldReceive('getMediaPath')
+            ->andReturn('https://example.com/media.jpg');
+
+        $dto->shouldReceive('getVisibility')
+            ->andReturn(0);
+
+        return $dto;
+    }
+
+    private function arrayData(): array
+    {
+        return [
+                'id' => 1,
+                'userId' => 1,
+                'content' => 'Sample content',
+                'mediaPath' => 'https://example.com/media.jpg',
+                'visibility' => 0,
+        ];
+    }
+
+    public function test_view_model_check_type(): void
+    {
+        $viewModel = new GetPostViewModel(
+            $this->arrayData()['id'],
+            $this->arrayData()['userId'],
+            $this->arrayData()['content'],
+            $this->arrayData()['mediaPath'],
+            $this->arrayData()['visibility']
+        );
+
+        $this->assertInstanceOf(GetPostViewModel::class, $viewModel);
+    }
+
+    public function test_view_model_check_value(): void
+    {
+        $viewModel = new GetPostViewModel(
+            $this->arrayData()['id'],
+            $this->arrayData()['userId'],
+            $this->arrayData()['content'],
+            $this->arrayData()['mediaPath'],
+            $this->arrayData()['visibility']
+        );
+
+        $this->assertEquals($viewModel->toArray()['id'], $this->mockPagination()->getData()['id']);
+        $this->assertEquals($viewModel->toArray()['userId'], $this->mockPagination()->getData()['userId']);
+        $this->assertEquals($viewModel->toArray()['content'], $this->mockPagination()->getData()['content']);
+        $this->assertEquals($viewModel->toArray()['mediaPath'], $this->mockPagination()->getData()['mediaPath']);
+        $this->assertEquals(
+            $viewModel->toArray()['visibility'],
+            $this->mockPagination()->getData()['visibility']
+        );
+    }
+}

--- a/src/app/Post/Presentation/ViewModel/GetPostViewModel.php
+++ b/src/app/Post/Presentation/ViewModel/GetPostViewModel.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace App\Post\Presentation\ViewModel;
+
+use App\Post\Application\Dto\GetUserEachPostDto;
+
+class GetPostViewModel
+{
+    public function __construct(
+        public readonly int $id,
+        public readonly int $userId,
+        public readonly string $content,
+        public readonly ?string $mediaPath,
+        public readonly string $visibility
+    ) {}
+
+    public static function build(GetUserEachPostDto $dto): self
+    {
+        return new self(
+            id: $dto->id,
+            userId: $dto->userId,
+            content: $dto->content,
+            mediaPath: $dto->mediaPath,
+            visibility: $dto->visibility
+        );
+    }
+
+    public function toArray(): array
+    {
+        return [
+            'id' => $this->id,
+            'userId' => $this->userId,
+            'content' => $this->content,
+            'mediaPath' => $this->mediaPath,
+            'visibility' => $this->visibility
+        ];
+    }
+}

--- a/src/app/Post/Presentation/ViewModel/GetPostsViewModelCollection.php
+++ b/src/app/Post/Presentation/ViewModel/GetPostsViewModelCollection.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace App\Post\Presentation\ViewModel;
+
+use App\Post\Application\Dto\GetAllUserPostDtoCollection;
+
+class GetPostsViewModelCollection
+{
+    private array $viewModels;
+
+    public function __construct(GetAllUserPostDtoCollection $dtoCollection)
+    {
+        $this->viewModels = array_map(
+            fn($dto) => GetPostViewModel::build($dto),
+            $dtoCollection->getPosts()
+        );
+    }
+
+    public function toArray(): array
+    {
+        return array_map(
+            fn(GetPostViewModel $vm) => $vm->toArray(),
+            $this->viewModels
+        );
+    }
+}


### PR DESCRIPTION
### Description

This PR merges the **Presentation Layer** implementation for retrieving posts made by other users (`getOthersPosts`).  
It includes:

- Controller method: `getOthersPosts()`
- ViewModel: `GetAllUserPostViewModel`
- ViewModelCollection (if applicable)
- PaginationViewModelFactory integration

---

### Implemented Components

#### 1. **Controller**
```php
public function getOthersPosts(
    Request $request,
    int $userId,
    GetOthersAllPostsUseCase $useCase
): JsonResponse
```

- Resolves route and query parameters (`userId`, `per_page`, `current_page`)
- Invokes `GetOthersAllPostsUseCase`
- Maps `GetUserEachPostDto` to `GetAllUserPostViewModel`
- Wraps in `PaginationViewModelFactory` for frontend consumption
- Returns structured JSON: `status`, `data`, `meta`

---

#### 2. **ViewModel: GetAllUserPostViewModel**
- Accepts a single `GetUserEachPostDto` via static `build()` method
- Exposes data via `toArray()`

---

#### 3. **PaginationViewModelFactory**
- Receives:
  - `$data` as `PaginationDto`
  - `$viewModels` as transformed array of DTOs
- Returns consistent pagination metadata and data structure
